### PR TITLE
fix: Fix the header href

### DIFF
--- a/packages/threat-statement-generator-demo-app/src/components/AppLayout/components/NavHeader/index.tsx
+++ b/packages/threat-statement-generator-demo-app/src/components/AppLayout/components/NavHeader/index.tsx
@@ -32,13 +32,13 @@ export interface NavHeaderProps extends Partial<TopNavigationProps> {
   /**
      * The href that the header links to
      */
-  href?: string;
+  href: string;
 }
 
 /**
  * Top Navigation Header displayed on AppLayout.
  */
-const NavHeader: FC<NavHeaderProps> = ({ title, href = '/', logo, ...props }) => {
+const NavHeader: FC<NavHeaderProps> = ({ title, href, logo, ...props }) => {
   const [theme, setTheme] = useState(Mode.Light);
   const [density, setDensity] = useState(Density.Comfortable);
   const utilities: TopNavigationProps.Utility[] = useMemo(() => {

--- a/packages/threat-statement-generator-demo-app/src/components/AppLayout/index.tsx
+++ b/packages/threat-statement-generator-demo-app/src/components/AppLayout/index.tsx
@@ -23,9 +23,11 @@ import SideNavigation, { SideNavigationProps } from '@cloudscape-design/componen
 import SplitPanel, { SplitPanelProps as SplitPanelComponentProps } from '@cloudscape-design/components/split-panel';
 import { TopNavigationProps } from '@cloudscape-design/components/top-navigation';
 import { FC, ReactNode, useState, useCallback, createContext, PropsWithChildren, ReactElement, useContext, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import NavHeader, { NavHeaderProps } from './components/NavHeader';
 import { splitPanelI18nStrings } from './constants';
+
+const defaultHref = process.env.PUBLIC_URL || '/';
 
 export type AppLayoutProps = (NavHeaderProps | { header: ReactElement<TopNavigationProps> })
 & {
@@ -103,6 +105,7 @@ const AppLayout: FC<PropsWithChildren<AppLayoutProps>> = ({
   ...props
 }) => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   const [contentType, setContentType] = useState(props.contentType);
 
@@ -117,14 +120,19 @@ const AppLayout: FC<PropsWithChildren<AppLayoutProps>> = ({
 
   const [notifications, setNotifications] = useState(props.notifications);
 
+  const headerHref = useMemo(() => {
+    const mode = searchParams.get('mode');
+    return mode ? `${defaultHref}/?mode=${mode}` : defaultHref;
+  }, [searchParams]);
+
   const [tools, setTools] = useState(props.tools);
   const [toolsHide, setToolsHide] = useState(props.toolsHide ?? true);
   const [toolsOpen, setToolsOpen] = useState(props.toolsOpen ?? false);
   const [toolsWidth, setToolsWidth] = useState(props.toolsWidth);
 
-  const [activeHref, setActiveHref] = useState('/');
+  const [activeHref, setActiveHref] = useState(headerHref);
   const [activeBreadcrumbs, setActiveBreadcrumbs] = useState<BreadcrumbGroupProps.Item[]>([
-    { text: defaultBreadcrumb, href: '/' },
+    { text: defaultBreadcrumb, href: headerHref },
   ]);
 
   const onNavigate: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail | SideNavigationProps.FollowDetail> =
@@ -180,7 +188,7 @@ const AppLayout: FC<PropsWithChildren<AppLayoutProps>> = ({
       ) : (
         props.navigationHide ? <NavHeader
           title={title}
-          href={props.href}
+          href={headerHref}
           logo={props.logo}
           {...headerProps}
         /> : undefined
@@ -198,7 +206,7 @@ const AppLayout: FC<PropsWithChildren<AppLayoutProps>> = ({
             props.navigation
           ) : (
             <SideNavigation
-              header={{ text: title, href: '/' }}
+              header={{ text: title, href: headerHref }}
               activeHref={activeHref}
               onFollow={onNavigate}
               items={props.navigationItems}

--- a/packages/threat-statement-generator/src/components/generic/Tooltip/index.css
+++ b/packages/threat-statement-generator/src/components/generic/Tooltip/index.css
@@ -21,12 +21,19 @@
 
 .tooltip-top {
   width: 110px;
-  bottom: 150%;
+  bottom: 125%;
   left: 50%;
   margin-left: -56px;
 }
 
-.tooltip .tooltiptext::after {
+.tooltip-bottom {
+  width: 110px;
+  top: 110%;
+  left: 50%;
+  margin-left: -56px;
+}
+
+.tooltip-top.tooltiptext::after {
   content: " ";
   position: absolute;
   top: 100%; /* At the bottom of the tooltip */
@@ -35,4 +42,15 @@
   border-width: 5px;
   border-style: solid;
   border-color: black transparent transparent transparent;
+}
+
+.tooltip-bottom.tooltiptext::after {
+  content: " ";
+  position: absolute;
+  bottom: 100%;  /* At the top of the tooltip */
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent black transparent;
 }

--- a/packages/threat-statement-generator/src/components/generic/Tooltip/index.tsx
+++ b/packages/threat-statement-generator/src/components/generic/Tooltip/index.tsx
@@ -18,15 +18,17 @@ import './index.css';
 
 export interface TooltipProps {
   tooltip: React.ReactNode;
+  anchor?: 'top' | 'bottom';
 }
 
 const Tooltip: FC<PropsWithChildren<TooltipProps>> = ({
   tooltip,
   children,
+  anchor = 'top',
 }) => {
   return <span className="tooltip">
     {children}
-    <span className="tooltiptext tooltip-top">{tooltip}</span>
+    <span className={`tooltiptext tooltip-${anchor}`}>{tooltip}</span>
   </span>;
 };
 

--- a/packages/threat-statement-generator/src/components/threats/ThreatStatementEditor/index.tsx
+++ b/packages/threat-statement-generator/src/components/threats/ThreatStatementEditor/index.tsx
@@ -122,9 +122,9 @@ const ThreatStatementEditorInner: FC<{ editingStatement: TemplateThreatStatement
       }
       const displayedHtml = displayedStatement?.map((s, index) => typeof s === 'string' ?
         s : s.type === 'b' ?
-          <Tooltip tooltip={s.tooltip} key={index} ><b className='threat-statement-editor-final-statement-section'>{s.content}</b></Tooltip> :
+          <Tooltip tooltip={s.tooltip} key={index} anchor={composerMode === 'EditorOnly'? 'bottom' : 'top'}><b className='threat-statement-editor-final-statement-section'>{s.content}</b></Tooltip> :
           s.type === 'span' ?
-            <Tooltip tooltip={s.tooltip} key={index}><span key={index} className='threat-statement-editor-final-statement-section'>{s.content}</span></Tooltip> :
+            <Tooltip tooltip={s.tooltip} key={index} anchor={composerMode === 'EditorOnly'? 'bottom' : 'top'}><span key={index} className='threat-statement-editor-final-statement-section'>{s.content}</span></Tooltip> :
             s.content);
 
       setDisplayStatement(displayedHtml);
@@ -133,7 +133,7 @@ const ThreatStatementEditorInner: FC<{ editingStatement: TemplateThreatStatement
       setSuggestions([]);
       setDisplayStatement([]);
     }
-  }, [editingStatement]);
+  }, [editingStatement, composerMode]);
 
   const handleStartOver = useCallback(() => {
     addStatement();

--- a/packages/threat-statement-generator/src/utils/renderThreatStatement/index.ts
+++ b/packages/threat-statement-generator/src/utils/renderThreatStatement/index.ts
@@ -145,7 +145,7 @@ const renderThreatStatement = (statement: TemplateThreatStatement): {
   });
 
   return {
-    statement: parseOutput.map(x => x.stringOutput).join(' ').replace(/\s\s+/g, ' '),
+    statement: parseOutput.map(x => x.stringOutput).join(' ').replace(/\s\s+/g, ' ').replace(/ ,/g, ','),
     displayedStatement: parseOutput.map(x => x.displayOutput),
     suggestions: suggestions.sort(),
   };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is to 
* fix the header href so that it can be used for Github page and different mode settings
* use bottom tooltip for EditorOnly mode so that users can see the full tooltip (was blocked to limited space on the top)
* fix the rendered statements where these is extra space before the comma

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
