### PR TITLE
fix: Add input validation to ImpactedAssets and ImpactedGoal editors. Close #17. 

### DIFF
--- a/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
+++ b/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
+import { error } from 'console';
 import CloudscapeAutosuggest, { AutosuggestProps as CloudscapeAutosuggestProps } from '@cloudscape-design/components/autosuggest';
 import FormField, { FormFieldProps } from '@cloudscape-design/components/form-field';
 import { BaseKeyDetail, CancelableEventHandler } from '@cloudscape-design/components/internal/events';
@@ -33,16 +34,15 @@ const Autosuggest: FC<AutosuggestProps> = React.forwardRef<CloudscapeAutosuggest
   ...props
 },
 ref) => {
-  const [displayedErrorText, setDisplayedErrorText] = useState<string>();
+  const [resetErrorText, setResetErrorText] = useState<boolean>();
   const { tempValue, errorText, handleChange } = useContentValidation(value, onChange, validateData);
-
-  useEffect(() => {
-    setDisplayedErrorText(errorText);
-  }, [errorText]);
 
   const handleKeyDown: CancelableEventHandler<BaseKeyDetail> = useCallback((event) => {
     if (event.detail.keyCode === 8 && !value && errorText) {
-      setDisplayedErrorText(undefined);
+      // When the value is empty, press backspace to reset the errorText.
+      setResetErrorText(true);
+    } else {
+      setResetErrorText(false);
     }
 
     props.onKeyDown?.(event);
@@ -52,7 +52,7 @@ ref) => {
   return (
     <FormField
       {...props}
-      errorText={displayedErrorText}
+      errorText={resetErrorText ? undefined : errorText}
     >
       <CloudscapeAutosuggest
         {...props}

--- a/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
+++ b/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
@@ -15,7 +15,8 @@
  ******************************************************************************************************************** */
 import CloudscapeAutosuggest, { AutosuggestProps as CloudscapeAutosuggestProps } from '@cloudscape-design/components/autosuggest';
 import FormField, { FormFieldProps } from '@cloudscape-design/components/form-field';
-import React, { FC } from 'react';
+import { BaseKeyDetail, CancelableEventHandler } from '@cloudscape-design/components/internal/events';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import { z } from 'zod';
 import useContentValidation from '../../../hooks/useContentValidation';
 
@@ -32,11 +33,26 @@ const Autosuggest: FC<AutosuggestProps> = React.forwardRef<CloudscapeAutosuggest
   ...props
 },
 ref) => {
+  const [displayedErrorText, setDisplayedErrorText] = useState<string>();
   const { tempValue, errorText, handleChange } = useContentValidation(value, onChange, validateData);
+
+  useEffect(() => {
+    setDisplayedErrorText(errorText);
+  }, [errorText]);
+
+  const handleKeyDown: CancelableEventHandler<BaseKeyDetail> = useCallback((event) => {
+    if (event.detail.keyCode === 8 && !value && errorText) {
+      setDisplayedErrorText(undefined);
+    }
+
+    props.onKeyDown?.(event);
+  },
+  [props.onKeyDown, errorText, value]);
+
   return (
     <FormField
       {...props}
-      errorText={errorText}
+      errorText={displayedErrorText}
     >
       <CloudscapeAutosuggest
         {...props}
@@ -45,6 +61,7 @@ ref) => {
         onChange={event =>
           handleChange(event)
         }
+        onKeyDown={handleKeyDown}
       />
     </FormField>);
 });

--- a/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
+++ b/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
@@ -1,0 +1,52 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ ******************************************************************************************************************** */
+import CloudscapeAutosuggest, { AutosuggestProps as CloudscapeAutosuggestProps } from '@cloudscape-design/components/autosuggest';
+import FormField, { FormFieldProps } from '@cloudscape-design/components/form-field';
+import React, { FC } from 'react';
+import { z } from 'zod';
+import useContentValidation from '../../../hooks/useContentValidation';
+
+export interface AutosuggestProps extends FormFieldProps, Omit<CloudscapeAutosuggestProps, 'errorText'> {
+  ref?: React.ForwardedRef<any>;
+  validateData?: (newValue: string) => z.SafeParseReturnType<string | undefined, string | undefined>;
+}
+
+const Autosuggest: FC<AutosuggestProps> = React.forwardRef<CloudscapeAutosuggestProps.Ref, AutosuggestProps>(({
+  onChange,
+  value,
+  validateData,
+  errorText: _errorText,
+  ...props
+},
+ref) => {
+  const { tempValue, errorText, handleChange } = useContentValidation(value, onChange, validateData);
+  return (
+    <FormField
+      {...props}
+      errorText={errorText}
+    >
+      <CloudscapeAutosuggest
+        {...props}
+        ref={ref}
+        value={errorText ? value : tempValue}
+        onChange={event =>
+          handleChange(event)
+        }
+      />
+    </FormField>);
+});
+
+export default Autosuggest;

--- a/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
+++ b/packages/threat-composer/src/components/generic/Autosuggest/index.tsx
@@ -13,11 +13,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import { error } from 'console';
 import CloudscapeAutosuggest, { AutosuggestProps as CloudscapeAutosuggestProps } from '@cloudscape-design/components/autosuggest';
 import FormField, { FormFieldProps } from '@cloudscape-design/components/form-field';
 import { BaseKeyDetail, CancelableEventHandler } from '@cloudscape-design/components/internal/events';
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { z } from 'zod';
 import useContentValidation from '../../../hooks/useContentValidation';
 

--- a/packages/threat-composer/src/components/generic/Textarea/index.tsx
+++ b/packages/threat-composer/src/components/generic/Textarea/index.tsx
@@ -14,23 +14,36 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import FormField, { FormFieldProps } from '@cloudscape-design/components/form-field';
+import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces';
+import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import TextareaComponent, { TextareaProps as TextareaComponetProps } from '@cloudscape-design/components/textarea';
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import { z } from 'zod';
 import useContentValidation from '../../../hooks/useContentValidation';
 
 export interface TextAreaProps extends FormFieldProps, TextareaComponetProps {
   ref?: React.ForwardedRef<any>;
   validateData?: (newValue: string) => z.SafeParseReturnType<string | undefined, string | undefined>;
+  singleLine?: boolean;
 }
 
 const Textarea: FC<TextAreaProps> = React.forwardRef<TextareaComponetProps.Ref, TextAreaProps>(({
   value,
   onChange,
   validateData,
+  singleLine,
   ...props
 }, ref) => {
   const { tempValue, errorText, handleChange } = useContentValidation(value, onChange, validateData);
+
+  const handleValueChange: NonCancelableEventHandler<BaseChangeDetail> = useCallback(event =>
+    singleLine ? handleChange({
+      ...event,
+      detail: {
+        ...event.detail,
+        value: event.detail.value.replace(/\n|\r/i, ' '),
+      },
+    }) : handleChange(event), [singleLine, handleChange]);
 
   return (
     <FormField
@@ -41,9 +54,7 @@ const Textarea: FC<TextAreaProps> = React.forwardRef<TextareaComponetProps.Ref, 
         {...props}
         ref={ref}
         value={tempValue}
-        onChange={event =>
-          handleChange(event)
-        }
+        onChange={handleValueChange}
       />
     </FormField>);
 });

--- a/packages/threat-composer/src/components/threats/EditorImpactedAssets/index.tsx
+++ b/packages/threat-composer/src/components/threats/EditorImpactedAssets/index.tsx
@@ -19,6 +19,7 @@ import { BaseKeyDetail, CancelableEventHandler, NonCancelableEventHandler } from
 import TokenGroup, { TokenGroupProps } from '@cloudscape-design/components/token-group';
 import { FC, useCallback, useState, forwardRef } from 'react';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
+import { ThreatStatementImpactedAssetItem } from '../../../customTypes';
 import Autosuggest from '../../generic/Autosuggest';
 import EditorLayout from '../EditorLayout';
 import ExampleList from '../ExampleList';
@@ -77,6 +78,7 @@ const EditorImpactedAssets: FC<EditorProps> = forwardRef<AutosuggestProps.Ref, E
       placeholder="Select an existing asset or enter new asset"
       empty="No matches found"
       onKeyDown={handleKeyDown}
+      validateData={ThreatStatementImpactedAssetItem.safeParse}
     />
     <TokenGroup
       onDismiss={handleRemoveAsset}

--- a/packages/threat-composer/src/components/threats/EditorImpactedAssets/index.tsx
+++ b/packages/threat-composer/src/components/threats/EditorImpactedAssets/index.tsx
@@ -14,11 +14,12 @@
   limitations under the License.
  ******************************************************************************************************************** */
 /** @jsxImportSource @emotion/react */
-import Autosuggest, { AutosuggestProps } from '@cloudscape-design/components/autosuggest';
+import { AutosuggestProps } from '@cloudscape-design/components/autosuggest';
 import { BaseKeyDetail, CancelableEventHandler, NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import TokenGroup, { TokenGroupProps } from '@cloudscape-design/components/token-group';
 import { FC, useCallback, useState, forwardRef } from 'react';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
+import Autosuggest from '../../generic/Autosuggest';
 import EditorLayout from '../EditorLayout';
 import ExampleList from '../ExampleList';
 import { EditorProps } from '../ThreatStatementEditor/types';

--- a/packages/threat-composer/src/components/threats/EditorImpactedGoal/index.tsx
+++ b/packages/threat-composer/src/components/threats/EditorImpactedGoal/index.tsx
@@ -19,6 +19,7 @@ import { BaseKeyDetail, CancelableEventHandler, NonCancelableEventHandler } from
 import TokenGroup, { TokenGroupProps } from '@cloudscape-design/components/token-group';
 import { FC, useCallback, useState, forwardRef } from 'react';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
+import { ThreatStatementImpactedGoalItem } from '../../../customTypes';
 import Autosuggest from '../../generic/Autosuggest';
 import EditorLayout from '../EditorLayout';
 import ExampleList from '../ExampleList';
@@ -85,6 +86,7 @@ const EditorImpactedGoal: FC<EditorProps> = forwardRef<AutosuggestProps.Ref, Edi
       placeholder="Select an impacted goal or enter new one"
       empty="No matches found"
       onKeyDown={handleKeyDown}
+      validateData={ThreatStatementImpactedGoalItem.safeParse}
     />
     <TokenGroup
       onDismiss={handleRemoveImpactedGoal}

--- a/packages/threat-composer/src/components/threats/EditorImpactedGoal/index.tsx
+++ b/packages/threat-composer/src/components/threats/EditorImpactedGoal/index.tsx
@@ -14,11 +14,12 @@
   limitations under the License.
  ******************************************************************************************************************** */
 /** @jsxImportSource @emotion/react */
-import Autosuggest, { AutosuggestProps } from '@cloudscape-design/components/autosuggest';
+import { AutosuggestProps } from '@cloudscape-design/components/autosuggest';
 import { BaseKeyDetail, CancelableEventHandler, NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import TokenGroup, { TokenGroupProps } from '@cloudscape-design/components/token-group';
 import { FC, useCallback, useState, forwardRef } from 'react';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
+import Autosuggest from '../../generic/Autosuggest';
 import EditorLayout from '../EditorLayout';
 import ExampleList from '../ExampleList';
 import { EditorProps } from '../ThreatStatementEditor/types';

--- a/packages/threat-composer/src/components/threats/EditorPrerequisites/index.tsx
+++ b/packages/threat-composer/src/components/threats/EditorPrerequisites/index.tsx
@@ -51,6 +51,7 @@ const EditorPrerequisites: FC<EditorProps> = forwardRef<TextareaProps.Ref, Edito
     inputRef.current?.focus();
   }, [handleChange]);
 
+
   return (<EditorLayout
     title={fieldData.displayTitle}
     description={fieldData.description}
@@ -63,6 +64,7 @@ const EditorPrerequisites: FC<EditorProps> = forwardRef<TextareaProps.Ref, Edito
           value={statement.prerequisites || ''}
           placeholder="Enter prerequisites"
           spellcheck
+          singleLine
           validateData={TemplateThreatStatementSchema.shape.prerequisites.safeParse}
           rows={2}
           stretch

--- a/packages/threat-composer/src/components/threats/EditorThreatAction/index.tsx
+++ b/packages/threat-composer/src/components/threats/EditorThreatAction/index.tsx
@@ -65,6 +65,7 @@ const EditorThreatAction: FC<EditorProps> = forwardRef<TextareaProps.Ref, Editor
           placeholder="Enter threat action"
           validateData={TemplateThreatStatementSchema.shape.threatAction.safeParse}
           rows={2}
+          singleLine
           stretch
         />
       </div>

--- a/packages/threat-composer/src/components/threats/EditorThreatImpact/index.tsx
+++ b/packages/threat-composer/src/components/threats/EditorThreatImpact/index.tsx
@@ -65,6 +65,7 @@ const EditorThreatImpact: FC<EditorProps> = forwardRef<TextareaProps.Ref, Editor
           placeholder="Enter threat impact"
           validateData={TemplateThreatStatementSchema.shape.threatImpact.safeParse}
           rows={2}
+          singleLine
           stretch
         />
       </div>

--- a/packages/threat-composer/src/customTypes/threats.ts
+++ b/packages/threat-composer/src/customTypes/threats.ts
@@ -34,6 +34,9 @@ export const ThreatStatementDisplayTokenSchema = z.object({
 
 export type ThreatStatementDisplayToken = z.infer<typeof ThreatStatementDisplayTokenSchema>;
 
+export const ThreatStatementImpactedGoalItem = z.string().max(SINGLE_FIELD_INPUT_MAX_LENGTH);
+
+export const ThreatStatementImpactedAssetItem = z.string().max(SINGLE_FIELD_INPUT_MAX_LENGTH);
 
 export const TemplateThreatStatementSchema = EntityBaseSchema.extend({
   /**
@@ -55,11 +58,11 @@ export const TemplateThreatStatementSchema = EntityBaseSchema.extend({
   /**
     * Impacted goal of the threat.
     */
-  impactedGoal: z.string().max(SINGLE_FIELD_INPUT_MAX_LENGTH).array().optional(),
+  impactedGoal: ThreatStatementImpactedGoalItem.array().optional(),
   /**
     * Impacted assets of the threat.
     */
-  impactedAssets: z.string().max(SINGLE_FIELD_INPUT_MAX_LENGTH).array().optional(),
+  impactedAssets: ThreatStatementImpactedAssetItem.array().optional(),
   /**
     * The full rendered statement as string.
     */
@@ -109,6 +112,5 @@ export const PerFieldExampleSchema = z.object({
     */
   stride: z.string().array().optional(),
 });
-
 
 export type PerFieldExample = z.infer<typeof PerFieldExampleSchema>;

--- a/packages/threat-composer/src/hooks/useContentValidation/index.tsx
+++ b/packages/threat-composer/src/hooks/useContentValidation/index.tsx
@@ -17,12 +17,13 @@ import { BaseChangeDetail } from '@cloudscape-design/components/input/interfaces
 import { NonCancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import { useCallback, useEffect, useState } from 'react';
 import { z } from 'zod';
-import { REGEX_CONTENT_NOT_HTML_TAG } from '../../configs';
+import sanitizeHtml from '../../utils/sanitizeHtml';
 
 const useContentValidation = (
   value: string,
   onChange?: NonCancelableEventHandler<BaseChangeDetail>,
-  validateData?: (newValue: string) => z.SafeParseReturnType<string | undefined, string | undefined>) => {
+  validateData?: (newValue: string) => z.SafeParseReturnType<string | undefined, string | undefined>,
+) => {
   const [tempValue, setTempValue] = useState(value);
   const [errorText, setErrorText] = useState('');
 
@@ -36,7 +37,8 @@ const useContentValidation = (
   const handleChange: NonCancelableEventHandler<BaseChangeDetail> = useCallback((event) => {
     const newValue = event.detail.value;
     setTempValue(newValue);
-    if (REGEX_CONTENT_NOT_HTML_TAG.test(newValue)) {
+    const cleanValue = sanitizeHtml(newValue);
+    if (cleanValue !== newValue) {
       setErrorText('Html tags not supported');
       return;
     }

--- a/packages/threat-composer/src/hooks/useContentValidation/index.tsx
+++ b/packages/threat-composer/src/hooks/useContentValidation/index.tsx
@@ -36,6 +36,7 @@ const useContentValidation = (
 
   const handleChange: NonCancelableEventHandler<BaseChangeDetail> = useCallback((event) => {
     const newValue = event.detail.value;
+    console.log(newValue);
     setTempValue(newValue);
     const cleanValue = sanitizeHtml(newValue);
     if (cleanValue !== newValue) {


### PR DESCRIPTION
*Issue #, if available:*

#17 

*Description of changes:*

This PR is to add  input validation to ImpactedAssets and ImpactedGoal editors to show warning messages when potential html tags are entered by the users so that the output in the threat statement list and threat model are consistent. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
