### PR TITLE
fix: Fix an issue where the deployment failed if lambda edge is used with Cloud Function

### DIFF
--- a/packages/threat-composer-infra/src/application-stack.ts
+++ b/packages/threat-composer-infra/src/application-stack.ts
@@ -13,284 +13,287 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-  import path from "path";
-  import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
-  import {
-    StaticWebsite,
-    StaticWebsiteOrigin,
-    StaticWebsiteProps,
-  } from "@aws-prototyping-sdk/static-website";
-  import { Stack, StackProps, CfnOutput, Stage, Duration } from "aws-cdk-lib";
-  import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
-  import {
-    DistributionProps,
-    LambdaEdgeEventType,
-    ResponseHeadersPolicy,
-    HeadersFrameOption,
-    HeadersReferrerPolicy,
-  } from "aws-cdk-lib/aws-cloudfront";
-  import { Version } from "aws-cdk-lib/aws-lambda";
-  import { HostedZone, ARecord, RecordTarget } from "aws-cdk-lib/aws-route53";
-  import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
-  import { NagSuppressions } from "cdk-nag";
-  import { Construct } from "constructs";
-  
-  const PACKAGES_ROOT = path.join(__dirname, "..", "..");
-  
-  export class ApplicationStack extends Stack {
-    constructor(scope: Construct, id: string, props?: StackProps) {
-      super(scope, id, props);
-  
-      const stageName = Stage.of(this)?.stageName;
-  
-      const domainName = this.node.tryGetContext(`domainName${stageName}`);
-      const certificate = this.node.tryGetContext(`certificate${stageName}`);
-      const hostedZoneId = this.node.tryGetContext(
-        `hostZone${stageName}`
-      ) as string;
-      const hostedZoneName = this.node.tryGetContext(
-        `hostZoneName${stageName}`
-      ) as string;
-      const lambdaEdge = this.node.tryGetContext(
-        `lambdaEdge${stageName}`
-      ) as string;
-      const cidrType = this.node.tryGetContext(`cidrType${stageName}`) as string;
-      const cidrRanges = this.node.tryGetContext(
-        `cidrRanges${stageName}`
-      ) as string;
-  
-      const contentSecurityPolicyOverride = this.node.tryGetContext(`contentSecurityPolicyOverride`) as string;
-  
-      const responseHeadersPolicy = new ResponseHeadersPolicy(
-        this,
-        "ResourceHeadersPolicy",
-        {
-          responseHeadersPolicyName: `ThreatComposerResourceHeadersPolicy${stageName}`,
-          corsBehavior: {
-            accessControlAllowCredentials: false,
-            accessControlAllowMethods: ["ALL"],
-            accessControlAllowOrigins: ["*"],
-            accessControlAllowHeaders: ["*"],
-            originOverride: true,
-          },
-          customHeadersBehavior: {
-            customHeaders: [
-              { header: "pragma", value: "no-cache", override: true },
-              {
-                header: "cache-control",
-                value: "no-store, no-cache",
-                override: true,
-              },
-            ],
-          },
-          securityHeadersBehavior: {
-            // A default content security policy is present in the index.html file to cater for github page hosting. 
-            // Here allow users to override to cater for specific use cases. 
-            contentSecurityPolicy: contentSecurityPolicyOverride ? {
+import path from "path";
+import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
+import {
+  StaticWebsite,
+  StaticWebsiteOrigin,
+  StaticWebsiteProps,
+} from "@aws-prototyping-sdk/static-website";
+import { Stack, StackProps, CfnOutput, Stage, Duration } from "aws-cdk-lib";
+import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
+import {
+  DistributionProps,
+  LambdaEdgeEventType,
+  ResponseHeadersPolicy,
+  HeadersFrameOption,
+  HeadersReferrerPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import { Version } from "aws-cdk-lib/aws-lambda";
+import { HostedZone, ARecord, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
+import { NagSuppressions } from "cdk-nag";
+import { Construct } from "constructs";
+
+const PACKAGES_ROOT = path.join(__dirname, "..", "..");
+
+export class ApplicationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const stageName = Stage.of(this)?.stageName;
+
+    const domainName = this.node.tryGetContext(`domainName${stageName}`);
+    const certificate = this.node.tryGetContext(`certificate${stageName}`);
+    const hostedZoneId = this.node.tryGetContext(
+      `hostZone${stageName}`
+    ) as string;
+    const hostedZoneName = this.node.tryGetContext(
+      `hostZoneName${stageName}`
+    ) as string;
+    const lambdaEdge = this.node.tryGetContext(
+      `lambdaEdge${stageName}`
+    ) as string;
+    const cidrType = this.node.tryGetContext(`cidrType${stageName}`) as string;
+    const cidrRanges = this.node.tryGetContext(
+      `cidrRanges${stageName}`
+    ) as string;
+
+    const contentSecurityPolicyOverride = this.node.tryGetContext(
+      `contentSecurityPolicyOverride`
+    ) as string;
+
+    const responseHeadersPolicy = new ResponseHeadersPolicy(
+      this,
+      "ResourceHeadersPolicy",
+      {
+        responseHeadersPolicyName: `ThreatComposerResourceHeadersPolicy${stageName}`,
+        corsBehavior: {
+          accessControlAllowCredentials: false,
+          accessControlAllowMethods: ["ALL"],
+          accessControlAllowOrigins: ["*"],
+          accessControlAllowHeaders: ["*"],
+          originOverride: true,
+        },
+        customHeadersBehavior: {
+          customHeaders: [
+            { header: "pragma", value: "no-cache", override: true },
+            {
+              header: "cache-control",
+              value: "no-store, no-cache",
+              override: true,
+            },
+          ],
+        },
+        securityHeadersBehavior: {
+          // A default content security policy is present in the index.html file to cater for github page hosting.
+          // Here allow users to override to cater for specific use cases.
+          contentSecurityPolicy: contentSecurityPolicyOverride
+            ? {
               contentSecurityPolicy: contentSecurityPolicyOverride,
               override: true,
-            } : undefined,
-            frameOptions: {
-              frameOption: HeadersFrameOption.DENY,
-              override: true,
-            },
-            referrerPolicy: {
-              referrerPolicy: HeadersReferrerPolicy.NO_REFERRER,
-              override: true,
-            },
-            strictTransportSecurity: {
-              accessControlMaxAge: Duration.seconds(63072000),
-              includeSubdomains: true,
-              preload: true,
-              override: true,
-            },
-            contentTypeOptions: { override: true },
+            }
+            : undefined,
+          frameOptions: {
+            frameOption: HeadersFrameOption.DENY,
+            override: true,
           },
+          referrerPolicy: {
+            referrerPolicy: HeadersReferrerPolicy.NO_REFERRER,
+            override: true,
+          },
+          strictTransportSecurity: {
+            accessControlMaxAge: Duration.seconds(63072000),
+            includeSubdomains: true,
+            preload: true,
+            override: true,
+          },
+          contentTypeOptions: { override: true },
+        },
+      }
+    );
+
+    let distributionProps: DistributionProps = {
+      defaultBehavior: {
+        origin: new StaticWebsiteOrigin(),
+        responseHeadersPolicy: responseHeadersPolicy,
+      },
+    };
+
+    if (domainName && certificate) {
+      distributionProps = {
+        ...distributionProps,
+        domainNames: [domainName],
+        certificate: Certificate.fromCertificateArn(
+          this,
+          "cloudfrontDistributionFromCertificateArn",
+          certificate
+        ),
+      };
+    }
+
+    if (lambdaEdge) {
+      distributionProps = {
+        ...distributionProps,
+        defaultBehavior: {
+          ...distributionProps.defaultBehavior,
+          edgeLambdas: [
+            {
+              functionVersion: Version.fromVersionArn(
+                this,
+                "LambdaEdgeFunctionVersion",
+                lambdaEdge
+              ),
+              eventType: LambdaEdgeEventType.VIEWER_REQUEST,
+            },
+          ],
+        },
+      };
+    }
+
+    const websiteProps: StaticWebsiteProps = {
+      websiteContentPath: path.join(
+        PACKAGES_ROOT,
+        "threat-composer-app",
+        "build"
+      ),
+      webAclProps: {
+        cidrAllowList: {
+          cidrType: cidrType === "IPV4" ? "IPV4" : "IPV6",
+          cidrRanges: cidrRanges
+            .split(",")
+            .map((x) => x.trim())
+            .filter((x) => !!x),
+        },
+      },
+      distributionProps,
+    };
+
+    const website = new StaticWebsite(this, "StaticWebsite", websiteProps);
+
+    if (hostedZoneId && hostedZoneName) {
+      const hostZone = HostedZone.fromHostedZoneAttributes(
+        this,
+        "HostZoneLookup",
+        {
+          hostedZoneId,
+          zoneName: hostedZoneName,
         }
       );
-  
-      let distributionProps: DistributionProps = {
-        defaultBehavior: {
-          origin: new StaticWebsiteOrigin(),
-          responseHeadersPolicy: responseHeadersPolicy,
-        },
-      };
-  
-      if (domainName && certificate) {
-        distributionProps = {
-          ...distributionProps,
-          domainNames: [domainName],
-          certificate: Certificate.fromCertificateArn(
-            this,
-            "cloudfrontDistributionFromCertificateArn",
-            certificate
-          ),
-        };
-      }
-  
-      if (lambdaEdge) {
-        distributionProps = {
-          ...distributionProps,
-          defaultBehavior: {
-            ...distributionProps.defaultBehavior,
-            edgeLambdas: [
-              {
-                functionVersion: Version.fromVersionArn(
-                  this,
-                  "LambdaEdgeFunctionVersion",
-                  lambdaEdge
-                ),
-                eventType: LambdaEdgeEventType.VIEWER_REQUEST,
-              },
-            ],
-          },
-        };
-      }
-  
-      const websiteProps: StaticWebsiteProps = {
-        websiteContentPath: path.join(
-          PACKAGES_ROOT,
-          "threat-composer-app",
-          "build"
+      new ARecord(this, "Route53Record", {
+        zone: hostZone,
+        recordName: domainName,
+        target: RecordTarget.fromAlias(
+          new CloudFrontTarget(website.cloudFrontDistribution)
         ),
-        webAclProps: {
-          cidrAllowList: {
-            cidrType: cidrType === "IPV4" ? "IPV4" : "IPV6",
-            cidrRanges: cidrRanges
-              .split(",")
-              .map((x) => x.trim())
-              .filter((x) => !!x),
-          },
-        },
-        distributionProps,
-      };
-  
-      const website = new StaticWebsite(this, "StaticWebsite", websiteProps);
-  
-      if (hostedZoneId && hostedZoneName) {
-        const hostZone = HostedZone.fromHostedZoneAttributes(
-          this,
-          "HostZoneLookup",
-          {
-            hostedZoneId,
-            zoneName: hostedZoneName,
-          }
-        );
-        new ARecord(this, "Route53Record", {
-          zone: hostZone,
-          recordName: domainName,
-          target: RecordTarget.fromAlias(
-            new CloudFrontTarget(website.cloudFrontDistribution)
-          ),
-        });
-      }
-  
-      this.suppressCDKNagViolations(websiteProps, website);
-  
-      new CfnOutput(this, "WebsiteCloudfrontDomainName", {
-        value: website.cloudFrontDistribution.domainName,
       });
     }
-  
-    private suppressCDKNagViolations = (
-      props: StaticWebsiteProps,
-      website: StaticWebsite
-    ) => {
-      const stack = Stack.of(this);
-      !props.distributionProps?.certificate &&
-        [
-          "AwsSolutions-CFR4",
-          "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
-        ].forEach((RuleId) => {
-          NagSuppressions.addResourceSuppressions(
-            website.cloudFrontDistribution,
-            [
-              {
-                id: RuleId,
-                reason:
-                  "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
-              },
-            ]
-          );
-        });
-  
-      ["AwsSolutions-L1", "AwsPrototyping-LambdaLatestVersion"].forEach(
-        (RuleId) => {
-          NagSuppressions.addResourceSuppressions(
-            this,
-            [
-              {
-                id: RuleId,
-                reason:
-                  "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
-              },
-            ],
-            true
-          );
-        }
-      );
-  
-      ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
-        (RuleId) => {
-          NagSuppressions.addResourceSuppressions(
-            this,
-            [
-              {
-                id: RuleId,
-                reason:
-                  "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
-                appliesTo: [
-                  {
-                    regex: "/^Action::s3:.*$/g",
-                  },
-                  {
-                    regex: `/^Resource::.*$/g`,
-                  },
-                ],
-              },
-            ],
-            true
-          );
-        }
-      );
-  
-      ["AwsSolutions-IAM4", "AwsPrototyping-IAMNoManagedPolicies"].forEach(
-        (RuleId) => {
-          NagSuppressions.addResourceSuppressions(
-            this,
-            [
-              {
-                id: RuleId,
-                reason:
-                  "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
-                appliesTo: [
-                  {
-                    regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
-                      stack
-                    )}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g`,
-                  },
-                ],
-              },
-            ],
-            true
-          );
-        }
-      );
-  
-      ["AwsSolutions-S1", "AwsPrototyping-S3BucketLoggingEnabled"].forEach(
-        (RuleId) => {
-          NagSuppressions.addResourceSuppressions(
-            this,
-            [
-              {
-                id: RuleId,
-                reason: "Access Log buckets should not have s3 bucket logging",
-              },
-            ],
-            true
-          );
-        }
-      );
-    };
+
+    this.suppressCDKNagViolations(websiteProps, website);
+
+    new CfnOutput(this, "WebsiteCloudfrontDomainName", {
+      value: website.cloudFrontDistribution.domainName,
+    });
   }
-  
+
+  private suppressCDKNagViolations = (
+    props: StaticWebsiteProps,
+    website: StaticWebsite
+  ) => {
+    const stack = Stack.of(this);
+    !props.distributionProps?.certificate &&
+      [
+        "AwsSolutions-CFR4",
+        "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
+      ].forEach((RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          website.cloudFrontDistribution,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+          ]
+        );
+      });
+
+    ["AwsSolutions-L1", "AwsPrototyping-LambdaLatestVersion"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          this,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+            },
+          ],
+          true
+        );
+      }
+    );
+
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          this,
+          [
+            {
+              id: RuleId,
+              reason:
+                "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+              appliesTo: [
+                {
+                  regex: "/^Action::s3:.*$/g",
+                },
+                {
+                  regex: `/^Resource::.*$/g`,
+                },
+              ],
+            },
+          ],
+          true
+        );
+      }
+    );
+
+    ["AwsSolutions-IAM4", "AwsPrototyping-IAMNoManagedPolicies"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          this,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+              appliesTo: [
+                {
+                  regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g`,
+                },
+              ],
+            },
+          ],
+          true
+        );
+      }
+    );
+
+    ["AwsSolutions-S1", "AwsPrototyping-S3BucketLoggingEnabled"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          this,
+          [
+            {
+              id: RuleId,
+              reason: "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+          true
+        );
+      }
+    );
+  };
+}

--- a/packages/threat-composer-infra/src/application-stack.ts
+++ b/packages/threat-composer-infra/src/application-stack.ts
@@ -13,260 +13,284 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import path from "path";
-import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
-import {
-  StaticWebsite,
-  StaticWebsiteOrigin,
-  StaticWebsiteProps,
-} from "@aws-prototyping-sdk/static-website";
-import { Stack, StackProps, CfnOutput, Stage } from "aws-cdk-lib";
-import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
-import {
-  DistributionProps,
-  LambdaEdgeEventType,
-  FunctionEventType,
-  Function,
-  FunctionCode,
-  ResponseHeadersPolicy,
-} from "aws-cdk-lib/aws-cloudfront";
-import { Version } from "aws-cdk-lib/aws-lambda";
-import { HostedZone, ARecord, RecordTarget } from "aws-cdk-lib/aws-route53";
-import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
-import { NagSuppressions } from "cdk-nag";
-import { Construct } from "constructs";
-
-const PACKAGES_ROOT = path.join(__dirname, "..", "..");
-
-export class ApplicationStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
-    super(scope, id, props);
-
-    const domainName = this.node.tryGetContext(
-      `domainName${Stage.of(this)?.stageName}`
-    );
-    const certificate = this.node.tryGetContext(
-      `certificate${Stage.of(this)?.stageName}`
-    );
-    const hostedZoneId = this.node.tryGetContext(
-      `hostZone${Stage.of(this)?.stageName}`
-    ) as string;
-    const hostedZoneName = this.node.tryGetContext(
-      `hostZoneName${Stage.of(this)?.stageName}`
-    ) as string;
-    const lambdaEdge = this.node.tryGetContext(
-      `lambdaEdge${Stage.of(this)?.stageName}`
-    ) as string;
-    const cidrType = this.node.tryGetContext(
-      `cidrType${Stage.of(this)?.stageName}`
-    ) as string;
-    const cidrRanges = this.node.tryGetContext(
-      `cidrRanges${Stage.of(this)?.stageName}`
-    ) as string;
-
-    let distributionProps: DistributionProps = {
-      defaultBehavior: {
-        origin: new StaticWebsiteOrigin(),
-        functionAssociations: lambdaEdge
-          ? undefined
-          : [
+  import path from "path";
+  import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
+  import {
+    StaticWebsite,
+    StaticWebsiteOrigin,
+    StaticWebsiteProps,
+  } from "@aws-prototyping-sdk/static-website";
+  import { Stack, StackProps, CfnOutput, Stage, Duration } from "aws-cdk-lib";
+  import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
+  import {
+    DistributionProps,
+    LambdaEdgeEventType,
+    ResponseHeadersPolicy,
+    HeadersFrameOption,
+    HeadersReferrerPolicy,
+  } from "aws-cdk-lib/aws-cloudfront";
+  import { Version } from "aws-cdk-lib/aws-lambda";
+  import { HostedZone, ARecord, RecordTarget } from "aws-cdk-lib/aws-route53";
+  import { CloudFrontTarget } from "aws-cdk-lib/aws-route53-targets";
+  import { NagSuppressions } from "cdk-nag";
+  import { Construct } from "constructs";
+  
+  const PACKAGES_ROOT = path.join(__dirname, "..", "..");
+  
+  export class ApplicationStack extends Stack {
+    constructor(scope: Construct, id: string, props?: StackProps) {
+      super(scope, id, props);
+  
+      const stageName = Stage.of(this)?.stageName;
+  
+      const domainName = this.node.tryGetContext(`domainName${stageName}`);
+      const certificate = this.node.tryGetContext(`certificate${stageName}`);
+      const hostedZoneId = this.node.tryGetContext(
+        `hostZone${stageName}`
+      ) as string;
+      const hostedZoneName = this.node.tryGetContext(
+        `hostZoneName${stageName}`
+      ) as string;
+      const lambdaEdge = this.node.tryGetContext(
+        `lambdaEdge${stageName}`
+      ) as string;
+      const cidrType = this.node.tryGetContext(`cidrType${stageName}`) as string;
+      const cidrRanges = this.node.tryGetContext(
+        `cidrRanges${stageName}`
+      ) as string;
+  
+      const contentSecurityPolicyOverride = this.node.tryGetContext(`contentSecurityPolicyOverride`) as string;
+  
+      const responseHeadersPolicy = new ResponseHeadersPolicy(
+        this,
+        "ResourceHeadersPolicy",
+        {
+          responseHeadersPolicyName: `ThreatComposerResourceHeadersPolicy${stageName}`,
+          corsBehavior: {
+            accessControlAllowCredentials: false,
+            accessControlAllowMethods: ["ALL"],
+            accessControlAllowOrigins: ["*"],
+            accessControlAllowHeaders: ["*"],
+            originOverride: true,
+          },
+          customHeadersBehavior: {
+            customHeaders: [
+              { header: "pragma", value: "no-cache", override: true },
               {
-                eventType: FunctionEventType.VIEWER_RESPONSE,
-                function: new Function(this, "ResponseHeaderFunction", {
-                  code: FunctionCode.fromInline(
-                    `function handler(event) { var response = event.response; 
-                  response.headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'}; 
-                  response.headers['x-content-type-options'] = { value: 'nosniff'}; 
-                  response.headers['x-frame-options'] = {value: 'DENY'}; 
-                  response.headers['cache-control'] = { value: 'no-store, no-cache'};
-                  response.headers['access-control-allow-origin'] = {value: '*'};
-                  response.headers['pragma'] = {value: 'no-cache'};
-                  return response; 
-                }`
-                  ),
-                }),
+                header: "cache-control",
+                value: "no-store, no-cache",
+                override: true,
               },
             ],
-        responseHeadersPolicy: lambdaEdge
-          ? ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS_AND_SECURITY_HEADERS
-          : undefined,
-      },
-    };
-
-    if (domainName && certificate) {
-      distributionProps = {
-        ...distributionProps,
-        domainNames: [domainName],
-        certificate: Certificate.fromCertificateArn(
-          this,
-          "cloudfrontDistributionFromCertificateArn",
-          certificate
-        ),
-      };
-    }
-
-    if (lambdaEdge) {
-      distributionProps = {
-        ...distributionProps,
-        defaultBehavior: {
-          ...distributionProps.defaultBehavior,
-          edgeLambdas: [
-            {
-              functionVersion: Version.fromVersionArn(
-                this,
-                "LambdaEdgeFunctionVersion",
-                lambdaEdge
-              ),
-              eventType: LambdaEdgeEventType.VIEWER_REQUEST,
+          },
+          securityHeadersBehavior: {
+            // A default content security policy is present in the index.html file to cater for github page hosting. 
+            // Here allow users to override to cater for specific use cases. 
+            contentSecurityPolicy: contentSecurityPolicyOverride ? {
+              contentSecurityPolicy: contentSecurityPolicyOverride,
+              override: true,
+            } : undefined,
+            frameOptions: {
+              frameOption: HeadersFrameOption.DENY,
+              override: true,
             },
-          ],
-        },
-      };
-    }
-
-    const websiteProps: StaticWebsiteProps = {
-      websiteContentPath: path.join(
-        PACKAGES_ROOT,
-        "threat-composer-app",
-        "build"
-      ),
-      webAclProps: {
-        cidrAllowList: {
-          cidrType: cidrType === "IPV4" ? "IPV4" : "IPV6",
-          cidrRanges: cidrRanges
-            .split(",")
-            .map((x) => x.trim())
-            .filter((x) => !!x),
-        },
-      },
-      distributionProps,
-    };
-
-    const website = new StaticWebsite(this, "StaticWebsite", websiteProps);
-
-    if (hostedZoneId && hostedZoneName) {
-      const hostZone = HostedZone.fromHostedZoneAttributes(
-        this,
-        "HostZoneLookup",
-        {
-          hostedZoneId,
-          zoneName: hostedZoneName,
+            referrerPolicy: {
+              referrerPolicy: HeadersReferrerPolicy.NO_REFERRER,
+              override: true,
+            },
+            strictTransportSecurity: {
+              accessControlMaxAge: Duration.seconds(63072000),
+              includeSubdomains: true,
+              preload: true,
+              override: true,
+            },
+            contentTypeOptions: { override: true },
+          },
         }
       );
-      new ARecord(this, "Route53Record", {
-        zone: hostZone,
-        recordName: domainName,
-        target: RecordTarget.fromAlias(
-          new CloudFrontTarget(website.cloudFrontDistribution)
+  
+      let distributionProps: DistributionProps = {
+        defaultBehavior: {
+          origin: new StaticWebsiteOrigin(),
+          responseHeadersPolicy: responseHeadersPolicy,
+        },
+      };
+  
+      if (domainName && certificate) {
+        distributionProps = {
+          ...distributionProps,
+          domainNames: [domainName],
+          certificate: Certificate.fromCertificateArn(
+            this,
+            "cloudfrontDistributionFromCertificateArn",
+            certificate
+          ),
+        };
+      }
+  
+      if (lambdaEdge) {
+        distributionProps = {
+          ...distributionProps,
+          defaultBehavior: {
+            ...distributionProps.defaultBehavior,
+            edgeLambdas: [
+              {
+                functionVersion: Version.fromVersionArn(
+                  this,
+                  "LambdaEdgeFunctionVersion",
+                  lambdaEdge
+                ),
+                eventType: LambdaEdgeEventType.VIEWER_REQUEST,
+              },
+            ],
+          },
+        };
+      }
+  
+      const websiteProps: StaticWebsiteProps = {
+        websiteContentPath: path.join(
+          PACKAGES_ROOT,
+          "threat-composer-app",
+          "build"
         ),
+        webAclProps: {
+          cidrAllowList: {
+            cidrType: cidrType === "IPV4" ? "IPV4" : "IPV6",
+            cidrRanges: cidrRanges
+              .split(",")
+              .map((x) => x.trim())
+              .filter((x) => !!x),
+          },
+        },
+        distributionProps,
+      };
+  
+      const website = new StaticWebsite(this, "StaticWebsite", websiteProps);
+  
+      if (hostedZoneId && hostedZoneName) {
+        const hostZone = HostedZone.fromHostedZoneAttributes(
+          this,
+          "HostZoneLookup",
+          {
+            hostedZoneId,
+            zoneName: hostedZoneName,
+          }
+        );
+        new ARecord(this, "Route53Record", {
+          zone: hostZone,
+          recordName: domainName,
+          target: RecordTarget.fromAlias(
+            new CloudFrontTarget(website.cloudFrontDistribution)
+          ),
+        });
+      }
+  
+      this.suppressCDKNagViolations(websiteProps, website);
+  
+      new CfnOutput(this, "WebsiteCloudfrontDomainName", {
+        value: website.cloudFrontDistribution.domainName,
       });
     }
-
-    this.suppressCDKNagViolations(websiteProps, website);
-
-    new CfnOutput(this, "WebsiteCloudfrontDomainName", {
-      value: website.cloudFrontDistribution.domainName,
-    });
+  
+    private suppressCDKNagViolations = (
+      props: StaticWebsiteProps,
+      website: StaticWebsite
+    ) => {
+      const stack = Stack.of(this);
+      !props.distributionProps?.certificate &&
+        [
+          "AwsSolutions-CFR4",
+          "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
+        ].forEach((RuleId) => {
+          NagSuppressions.addResourceSuppressions(
+            website.cloudFrontDistribution,
+            [
+              {
+                id: RuleId,
+                reason:
+                  "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+              },
+            ]
+          );
+        });
+  
+      ["AwsSolutions-L1", "AwsPrototyping-LambdaLatestVersion"].forEach(
+        (RuleId) => {
+          NagSuppressions.addResourceSuppressions(
+            this,
+            [
+              {
+                id: RuleId,
+                reason:
+                  "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+              },
+            ],
+            true
+          );
+        }
+      );
+  
+      ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+        (RuleId) => {
+          NagSuppressions.addResourceSuppressions(
+            this,
+            [
+              {
+                id: RuleId,
+                reason:
+                  "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+                appliesTo: [
+                  {
+                    regex: "/^Action::s3:.*$/g",
+                  },
+                  {
+                    regex: `/^Resource::.*$/g`,
+                  },
+                ],
+              },
+            ],
+            true
+          );
+        }
+      );
+  
+      ["AwsSolutions-IAM4", "AwsPrototyping-IAMNoManagedPolicies"].forEach(
+        (RuleId) => {
+          NagSuppressions.addResourceSuppressions(
+            this,
+            [
+              {
+                id: RuleId,
+                reason:
+                  "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+                appliesTo: [
+                  {
+                    regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
+                      stack
+                    )}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g`,
+                  },
+                ],
+              },
+            ],
+            true
+          );
+        }
+      );
+  
+      ["AwsSolutions-S1", "AwsPrototyping-S3BucketLoggingEnabled"].forEach(
+        (RuleId) => {
+          NagSuppressions.addResourceSuppressions(
+            this,
+            [
+              {
+                id: RuleId,
+                reason: "Access Log buckets should not have s3 bucket logging",
+              },
+            ],
+            true
+          );
+        }
+      );
+    };
   }
-
-  private suppressCDKNagViolations = (
-    props: StaticWebsiteProps,
-    website: StaticWebsite
-  ) => {
-    const stack = Stack.of(this);
-    !props.distributionProps?.certificate &&
-      [
-        "AwsSolutions-CFR4",
-        "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
-      ].forEach((RuleId) => {
-        NagSuppressions.addResourceSuppressions(
-          website.cloudFrontDistribution,
-          [
-            {
-              id: RuleId,
-              reason:
-                "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
-            },
-          ]
-        );
-      });
-
-    ["AwsSolutions-L1", "AwsPrototyping-LambdaLatestVersion"].forEach(
-      (RuleId) => {
-        NagSuppressions.addResourceSuppressions(
-          this,
-          [
-            {
-              id: RuleId,
-              reason:
-                "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
-            },
-          ],
-          true
-        );
-      }
-    );
-
-    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
-      (RuleId) => {
-        NagSuppressions.addResourceSuppressions(
-          this,
-          [
-            {
-              id: RuleId,
-              reason:
-                "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
-              appliesTo: [
-                {
-                  regex: "/^Action::s3:.*$/g",
-                },
-                {
-                  regex: `/^Resource::.*$/g`,
-                },
-              ],
-            },
-          ],
-          true
-        );
-      }
-    );
-
-    ["AwsSolutions-IAM4", "AwsPrototyping-IAMNoManagedPolicies"].forEach(
-      (RuleId) => {
-        NagSuppressions.addResourceSuppressions(
-          this,
-          [
-            {
-              id: RuleId,
-              reason:
-                "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
-              appliesTo: [
-                {
-                  regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
-                    stack
-                  )}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g`,
-                },
-              ],
-            },
-          ],
-          true
-        );
-      }
-    );
-
-    ["AwsSolutions-S1", "AwsPrototyping-S3BucketLoggingEnabled"].forEach(
-      (RuleId) => {
-        NagSuppressions.addResourceSuppressions(
-          this,
-          [
-            {
-              id: RuleId,
-              reason: "Access Log buckets should not have s3 bucket logging",
-            },
-          ],
-          true
-        );
-      }
-    );
-  };
-}
+  

--- a/packages/threat-composer/src/containers/LandingPage/index.tsx
+++ b/packages/threat-composer/src/containers/LandingPage/index.tsx
@@ -17,10 +17,10 @@ import React, { FC } from 'react';
 import LandingPageComponent from '../../components/workspaces/LandingPage';
 import { ContextAggregator } from '../../contexts';
 
-const WorkspaceHome: FC = () => {
+const LandingPage: FC = () => {
   return (<ContextAggregator composerMode='Full'>
     <LandingPageComponent/>
   </ContextAggregator>);
 };
 
-export default WorkspaceHome;
+export default LandingPage;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The infra deployment will fail if lambda edge ARN is provided because [lambda edge cannot be used together with CloudFunction on viewer request event](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html).

The solution here is to use custom ResponseHeadersPolicy to inject security headers.






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
