### PR TITLE
feat: Sort tags/assets in alphabetic order and allow filtering on tags/assets

### DIFF
--- a/packages/threat-composer/src/components/application/ApplicationInfo/index.tsx
+++ b/packages/threat-composer/src/components/application/ApplicationInfo/index.tsx
@@ -18,18 +18,24 @@ import Container from '@cloudscape-design/components/container';
 import FormField from '@cloudscape-design/components/form-field';
 import Header from '@cloudscape-design/components/header';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import { FC, useState, useCallback, useMemo } from 'react';
+import { FC, useState, useCallback, useMemo, useEffect } from 'react';
 import { useApplicationInfoContext } from '../../../contexts/ApplicationContext/context';
-import { ApplicationInfoSchema } from '../../../customTypes';
+import { ApplicationInfoSchema, EditableComponentBaseProps } from '../../../customTypes';
 import Input from '../../generic/Input';
 import MarkdownEditor from '../../generic/MarkdownEditor';
 import MarkdownViewer from '../../generic/MarkdownViewer';
 
-const ApplicationInfo: FC = () => {
+const ApplicationInfo: FC<EditableComponentBaseProps> = ({
+  onEditModeChange,
+}) => {
   const { applicationInfo, setApplicationInfo } = useApplicationInfoContext();
   const [editMode, setEditMode] = useState(!applicationInfo.name && !applicationInfo.description );
   const [content, setContent] = useState('');
   const [name, setName] = useState('');
+
+  useEffect(() => {
+    onEditModeChange?.(editMode);
+  }, [editMode]);
 
   const handleSaveApplicationInfo = useCallback(() => {
     setApplicationInfo(prev => ({

--- a/packages/threat-composer/src/components/architecture/ArchitectureInfo/index.tsx
+++ b/packages/threat-composer/src/components/architecture/ArchitectureInfo/index.tsx
@@ -15,12 +15,13 @@
  ******************************************************************************************************************** */
 import { FC } from 'react';
 import { useArchitectureInfoContext } from '../../../contexts/ArchitectureContext/context';
-import { ArchitectureInfoSchema } from '../../../customTypes';
+import { ArchitectureInfoSchema, EditableComponentBaseProps } from '../../../customTypes';
 import BaseDiagramInfo from '../../generic/BaseDiagramInfo';
 
-const ArchitectureInfo: FC = () => {
+const ArchitectureInfo: FC<EditableComponentBaseProps> = (props) => {
   const { architectureInfo, setArchitectureInfo } = useArchitectureInfoContext();
   return <BaseDiagramInfo
+    {...props}
     headerTitle='Architecture'
     diagramTitle='Architecture Diagram'
     entity={architectureInfo}

--- a/packages/threat-composer/src/components/assumptions/AssumptionList/index.tsx
+++ b/packages/threat-composer/src/components/assumptions/AssumptionList/index.tsx
@@ -17,7 +17,6 @@ import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
 import Grid from '@cloudscape-design/components/grid';
 import Header from '@cloudscape-design/components/header';
-import Multiselect from '@cloudscape-design/components/multiselect';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import { FC, useCallback, useMemo, useState } from 'react';
@@ -26,6 +25,7 @@ import { useAssumptionsContext } from '../../../contexts/AssumptionsContext/cont
 import { Assumption, AssumptionLink } from '../../../customTypes';
 import { addTagToEntity, removeTagFromEntity } from '../../../utils/entityTag';
 import LinkedEntityFilter, { ALL, WITHOUT_NO_LINKED_ENTITY, WITH_LINKED_ENTITY } from '../../generic/LinkedEntityFilter';
+import TagSelector from '../../generic/TagSelector';
 import AssumptionCard from '../AssumptionCard';
 import AssumptionCreationCard from '../AssumptionCreationCard';
 
@@ -180,22 +180,10 @@ const AssumptionList: FC = () => {
               { colspan: { default: 1 } },
             ]}
           >
-            <Multiselect
-              tokenLimit={0}
-              selectedOptions={selectedTags.map(ia => ({
-                label: ia,
-                value: ia,
-              }))}
-              onChange={({ detail }) =>
-                setSelectedTags(detail.selectedOptions?.map(o => o.value || '') || [])
-              }
-              deselectAriaLabel={e => `Remove ${e.label}`}
-              options={allTags.map(g => ({
-                label: g,
-                value: g,
-              }))}
-              placeholder="Filtered by tags"
-              selectedAriaLabel="Selected"
+            <TagSelector
+              allTags={allTags}
+              selectedTags={selectedTags}
+              setSelectedTags={setSelectedTags}
             />
             <LinkedEntityFilter
               label='Linked threats'

--- a/packages/threat-composer/src/components/dataflow/DataflowInfo/index.tsx
+++ b/packages/threat-composer/src/components/dataflow/DataflowInfo/index.tsx
@@ -15,12 +15,13 @@
  ******************************************************************************************************************** */
 import { FC } from 'react';
 import { useDataflowInfoContext } from '../../../contexts/DataflowContext/context';
-import { DataflowInfoSchema } from '../../../customTypes';
+import { DataflowInfoSchema, EditableComponentBaseProps } from '../../../customTypes';
 import BaseDiagramInfo from '../../generic/BaseDiagramInfo';
 
-const DataflowInfo: FC = () => {
+const DataflowInfo: FC<EditableComponentBaseProps> = (props) => {
   const { dataflowInfo, setDataflowInfo } = useDataflowInfoContext();
   return <BaseDiagramInfo
+    {...props}
     headerTitle='Dataflow'
     diagramTitle='Dataflow Diagram'
     entity={dataflowInfo}

--- a/packages/threat-composer/src/components/generic/AssetSelector/index.tsx
+++ b/packages/threat-composer/src/components/generic/AssetSelector/index.tsx
@@ -1,0 +1,56 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ ******************************************************************************************************************** */
+import Multiselect from '@cloudscape-design/components/multiselect';
+import React, { FC, useMemo } from 'react';
+
+export interface AssetSelectorProps {
+  allAssets: string[];
+  selectedAssets: string[];
+  setSelectedAssets: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+const AssetSelector: FC<AssetSelectorProps> = ({
+  allAssets,
+  selectedAssets,
+  setSelectedAssets,
+}) => {
+  const sortedAssets = useMemo(() => {
+    return allAssets.sort((a, b) => {
+      return a.toLowerCase().localeCompare(b.toLowerCase());
+    });
+  }, [allAssets]);
+
+  return (<Multiselect
+    tokenLimit={0}
+    selectedOptions={selectedAssets.map(ia => ({
+      label: ia,
+      value: ia,
+    }))}
+    onChange={({ detail }) =>
+      setSelectedAssets(detail.selectedOptions?.map(o => o.value || '') || [])
+    }
+    deselectAriaLabel={e => `Remove ${e.label}`}
+    options={sortedAssets.map(g => ({
+      label: g,
+      value: g,
+    }))}
+    filteringType="auto"
+    placeholder="Filtered by Assets"
+    selectedAriaLabel="Selected"
+  />);
+};
+
+export default AssetSelector;

--- a/packages/threat-composer/src/components/generic/BaseDiagramInfo/index.tsx
+++ b/packages/threat-composer/src/components/generic/BaseDiagramInfo/index.tsx
@@ -18,14 +18,14 @@ import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import { FC, useCallback, useState, useMemo } from 'react';
-import { BaseImageInfo } from '../../../customTypes';
+import { FC, useCallback, useState, useMemo, useEffect } from 'react';
+import { BaseImageInfo, EditableComponentBaseProps } from '../../../customTypes';
 import imageStyles from '../../../styles/image';
 import ImageEdit from '../ImageEdit';
 import MarkdownEditor, { MarkdownEditorProps } from '../MarkdownEditor';
 import MarkdownViewer from '../MarkdownViewer';
 
-export interface BaseDiagramInfoProps {
+export interface BaseDiagramInfoProps extends EditableComponentBaseProps {
   entity: BaseImageInfo;
   headerTitle: string;
   diagramTitle: string;
@@ -39,10 +39,15 @@ const BaseDiagramInfo: FC<BaseDiagramInfoProps> = ({
   entity,
   onConfirm,
   validateData,
+  onEditModeChange,
 }) => {
   const [editMode, setEditMode] = useState(!entity.description && !entity.image);
   const [image, setImage] = useState<string>('');
   const [content, setContent] = useState('');
+
+  useEffect(() => {
+    onEditModeChange?.(editMode);
+  }, [editMode]);
 
   const handleSaveDiagramInfo = useCallback(() => {
     onConfirm({

--- a/packages/threat-composer/src/components/generic/TagSelector/index.tsx
+++ b/packages/threat-composer/src/components/generic/TagSelector/index.tsx
@@ -1,0 +1,56 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ ******************************************************************************************************************** */
+import Multiselect from '@cloudscape-design/components/multiselect';
+import React, { FC, useMemo } from 'react';
+
+export interface TagSelectorProps {
+  allTags: string[];
+  selectedTags: string[];
+  setSelectedTags: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+const TagSelector: FC<TagSelectorProps> = ({
+  allTags,
+  selectedTags,
+  setSelectedTags,
+}) => {
+  const sortedTags = useMemo(() => {
+    return allTags.sort((a, b) => {
+      return a.toLowerCase().localeCompare(b.toLowerCase());
+    });
+  }, [allTags]);
+
+  return (<Multiselect
+    tokenLimit={0}
+    selectedOptions={selectedTags.map(ia => ({
+      label: ia,
+      value: ia,
+    }))}
+    onChange={({ detail }) =>
+      setSelectedTags(detail.selectedOptions?.map(o => o.value || '') || [])
+    }
+    deselectAriaLabel={e => `Remove ${e.label}`}
+    options={sortedTags.map(g => ({
+      label: g,
+      value: g,
+    }))}
+    filteringType="auto"
+    placeholder="Filtered by tags"
+    selectedAriaLabel="Selected"
+  />);
+};
+
+export default TagSelector;

--- a/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
+++ b/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
@@ -17,7 +17,6 @@ import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
 import Grid from '@cloudscape-design/components/grid';
 import Header from '@cloudscape-design/components/header';
-import Multiselect from '@cloudscape-design/components/multiselect';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import { FC, useCallback, useMemo, useState } from 'react';
@@ -25,6 +24,7 @@ import { useAssumptionLinksContext, useMitigationLinksContext } from '../../../c
 import { useMitigationsContext } from '../../../contexts/MitigationsContext/context';
 import { AssumptionLink, Mitigation, MitigationLink } from '../../../customTypes';
 import LinkedEntityFilter, { ALL, WITHOUT_NO_LINKED_ENTITY, WITH_LINKED_ENTITY } from '../../generic/LinkedEntityFilter';
+import TagSelector from '../../generic/TagSelector';
 import MitigationCard from '../MitigationCard';
 import MitigationCreationCard from '../MitigationCreationCard';
 
@@ -199,22 +199,10 @@ const MitigationList: FC = () => {
               { colspan: { default: 1 } },
             ]}
           >
-            <Multiselect
-              tokenLimit={0}
-              selectedOptions={selectedTags.map(ia => ({
-                label: ia,
-                value: ia,
-              }))}
-              onChange={({ detail }) =>
-                setSelectedTags(detail.selectedOptions?.map(o => o.value || '') || [])
-              }
-              deselectAriaLabel={e => `Remove ${e.label}`}
-              options={allTags.map(g => ({
-                label: g,
-                value: g,
-              }))}
-              placeholder="Filtered by tags"
-              selectedAriaLabel="Selected"
+            <TagSelector
+              allTags={allTags}
+              selectedTags={selectedTags}
+              setSelectedTags={setSelectedTags}
             />
             <LinkedEntityFilter
               label='Linked threats'

--- a/packages/threat-composer/src/components/threats/ThreatStatementList/index.tsx
+++ b/packages/threat-composer/src/components/threats/ThreatStatementList/index.tsx
@@ -30,8 +30,10 @@ import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
 import { TemplateThreatStatement, ThreatStatementListFilter } from '../../../customTypes';
 import useEditMetadata from '../../../hooks/useEditMetadata';
 import { addTagToEntity, removeTagFromEntity } from '../../../utils/entityTag';
+import AssetSelector from '../../generic/AssetSelector';
 import LinkedEntityFilter, { ALL, WITHOUT_NO_LINKED_ENTITY, WITH_LINKED_ENTITY } from '../../generic/LinkedEntityFilter';
 import { OPTIONS as STRIDEOptions } from '../../generic/STRIDESelector';
+import TagSelector from '../../generic/TagSelector';
 import WorkspaceSelector from '../../workspaces/WorkspaceSelector';
 import SortByComponent, { SortByOption, DEFAULT_SORT_BY } from '../SortBy';
 import ThreatStatementCard from '../ThreatStatementCard';
@@ -392,22 +394,10 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
               placeholder="Filtered by STRIDE"
               selectedAriaLabel="Selected"
             />
-            <Multiselect
-              tokenLimit={0}
-              selectedOptions={selectedImpactedAssets.map(ia => ({
-                label: ia,
-                value: ia,
-              }))}
-              onChange={({ detail }) =>
-                setSelectedImpactedAssets(detail.selectedOptions?.map(o => o.value || '') || [])
-              }
-              deselectAriaLabel={e => `Remove ${e.label}`}
-              options={allImpactedAssets.map(g => ({
-                label: g,
-                value: g,
-              }))}
-              placeholder="Filtered by impacted assets"
-              selectedAriaLabel="Selected"
+            <AssetSelector
+              allAssets={allImpactedAssets}
+              selectedAssets={selectedImpactedAssets}
+              setSelectedAssets={setSelectedImpactedAssets}
             />
             <Multiselect
               tokenLimit={0}
@@ -426,22 +416,10 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
               placeholder="Filtered by impacted goal"
               selectedAriaLabel="Selected"
             />
-            <Multiselect
-              tokenLimit={0}
-              selectedOptions={selectedTags.map(ia => ({
-                label: ia,
-                value: ia,
-              }))}
-              onChange={({ detail }) =>
-                setSelectedTags(detail.selectedOptions?.map(o => o.value || '') || [])
-              }
-              deselectAriaLabel={e => `Remove ${e.label}`}
-              options={allTags.map(g => ({
-                label: g,
-                value: g,
-              }))}
-              placeholder="Filtered by tags"
-              selectedAriaLabel="Selected"
+            <TagSelector
+              allTags={allTags}
+              selectedTags={selectedTags}
+              setSelectedTags={setSelectedTags}
             />
             {composerMode === 'Full' && <LinkedEntityFilter
               label='Linked mitigations'

--- a/packages/threat-composer/src/components/workspaces/WorkspaceSelector/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceSelector/index.tsx
@@ -85,11 +85,6 @@ const WorkspaceSelector: FC<PropsWithChildren<WorkspaceSelectorProps>> = ({
       })),
     });
 
-    options.push({
-      label: 'Add new workspace',
-      value: '[AddNewWorkspace]',
-    });
-
     return options;
   }, [workspaceList]);
 
@@ -97,8 +92,6 @@ const WorkspaceSelector: FC<PropsWithChildren<WorkspaceSelectorProps>> = ({
     const selectedItem = detail.selectedOption;
     if (selectedItem.value === DEFAULT_WORKSPACE_ID) {
       switchWorkspace(null);
-    } else if (selectedItem.value === '[AddNewWorkspace]') {
-      setAddWorkspaceModalVisible(true);
     } else {
       selectedItem.value && selectedItem.label && switchWorkspace({
         id: selectedItem.value,
@@ -109,6 +102,9 @@ const WorkspaceSelector: FC<PropsWithChildren<WorkspaceSelectorProps>> = ({
 
   const handleMoreActions: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails> = useCallback(async ({ detail }) => {
     switch (detail.id) {
+      case 'add':
+        setAddWorkspaceModalVisible(true);
+        break;
       case 'import':
         setFileImportModalVisible(true);
         break;
@@ -139,6 +135,7 @@ const WorkspaceSelector: FC<PropsWithChildren<WorkspaceSelectorProps>> = ({
     currentWorkspace,
     setRemoveDataModalVisible,
     setRemoveWorkspaceModalVisible,
+    setAddWorkspaceModalVisible,
   ]);
 
   const handleRemoveData = useCallback(async () => {
@@ -184,6 +181,7 @@ const WorkspaceSelector: FC<PropsWithChildren<WorkspaceSelectorProps>> = ({
       <ButtonDropdown
         items={[
           ...[
+            { id: 'add', text: 'Add new workspace' },
             { id: 'import', text: 'Import' },
             {
               id: 'exportAll',

--- a/packages/threat-composer/src/customTypes/components.ts
+++ b/packages/threat-composer/src/customTypes/components.ts
@@ -13,16 +13,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-export * from './assumptions';
-export * from './mitigations';
-export * from './threats';
-export * from './threatFieldTypes';
-export * from './workspaces';
-export * from './entities';
-export * from './composerMode';
-export * from './application';
-export * from './architecture';
-export * from './dataflow';
-export * from './dataExchange';
-export * from './events';
-export * from './components';
+export interface EditableComponentBaseProps {
+  onEditModeChange?: (editMode: boolean) => void;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR includes changes:
* Sort tags in alphabetic order and allow filtering on tags
* Sort assets in alphabetic order and allow filtering on assets
* Move the **Add new workspace** button into the dropdown menu

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
