### PR TITLE
feat(App): Rename 'Home' to 'Dashboard'

### DIFF
--- a/packages/threat-composer-app/src/components/FullAppLayout/index.tsx
+++ b/packages/threat-composer-app/src/components/FullAppLayout/index.tsx
@@ -79,7 +79,7 @@ export const AppLayoutContext = createContext<AppLayoutContextApi>(initialState)
  */
 const AppLayout: FC<PropsWithChildren<AppLayoutProps>> = ({
   title,
-  defaultBreadcrumb = 'home',
+  defaultBreadcrumb = 'dashboard',
   children,
   headerProps,
   breadcrumbGroupHide,

--- a/packages/threat-composer-app/src/config/routes.ts
+++ b/packages/threat-composer-app/src/config/routes.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-export const ROUTE_WORKSPACE_HOME = '/workspaces/:workspaceId/home';
+export const ROUTE_WORKSPACE_HOME = '/workspaces/:workspaceId/dashboard';
 export const ROUTE_THREAT_LIST = '/workspaces/:workspaceId/threats';
 export const ROUTE_THREAT_EDITOR = '/workspaces/:workspaceId/threats/:threatId';
 export const ROUTE_MITIGATION_LIST = '/workspaces/:workspaceId/mitigations';

--- a/packages/threat-composer-app/src/containers/App/components/Full/index.tsx
+++ b/packages/threat-composer-app/src/containers/App/components/Full/index.tsx
@@ -82,7 +82,7 @@ const Full: FC = () => {
   const navigationItems: SideNavigationProps.Item[] = useMemo(() => {
     return [
       {
-        text: 'Home',
+        text: 'Dashboard',
         href: generateUrl(ROUTE_WORKSPACE_HOME, searchParms, workspaceId),
         type: 'link',
       },

--- a/packages/threat-composer-app/src/hooks/useSetActiveBreadCrumbs/index.ts
+++ b/packages/threat-composer-app/src/hooks/useSetActiveBreadCrumbs/index.ts
@@ -26,7 +26,7 @@ const useSetActiveBreadcrumbGroup = (additionPaths?: BreadcrumbGroupProps.Item[]
     setActiveBreadcrumbs([
       {
         href: currentPath,
-        text: 'home',
+        text: 'dashboard',
       },
       {
         href: currentPath,


### PR DESCRIPTION
*Description of changes:*
- Renames 'Home' to 'Dashboard' for better discoverability of Insights Dashboard feature


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
