### PR TITLE
fix: Fix the issue where import failed without clear prompt when image size exceeds the maximum size file. Close #62

### DIFF
--- a/packages/threat-composer/src/components/generic/FileUpload/components/FileTokenLabel/index.tsx
+++ b/packages/threat-composer/src/components/generic/FileUpload/components/FileTokenLabel/index.tsx
@@ -33,7 +33,7 @@ const FileTokenLabel: FC<FileTokenLabelProps> = ({ name, size, lastModified }) =
       <TextContent>
         <Spacebetween direction="vertical" size="xxxs">
           <span key='name'><b>{name}</b></span>
-          <span key='size'>{getDisplaySize(size)}</span>
+          <span key='size'>Size: {getDisplaySize(size)}</span>
           {lastModified && <span key='lastModified'>{getDisplayLastModified(lastModified)}</span>}
         </Spacebetween>
       </TextContent>

--- a/packages/threat-composer/src/components/generic/FileUpload/index.tsx
+++ b/packages/threat-composer/src/components/generic/FileUpload/index.tsx
@@ -16,11 +16,13 @@
 import Button from '@cloudscape-design/components/button';
 import FormField, { FormFieldProps } from '@cloudscape-design/components/form-field';
 import SpaceBetween from '@cloudscape-design/components/space-between';
-import React, { FC, useCallback, useRef, useMemo } from 'react';
+import React, { FC, useCallback, useRef, useMemo, useState, useEffect } from 'react';
 import FileTokenLabel from './components/FileTokenLabel';
+import getDisplaySize from './utils/getDisplaySize';
 
 export interface FileUploadProps extends FormFieldProps {
   accept?: string;
+  sizeLimit?: number;
   buttonText?: string;
   name?: string;
   onChange?: (files: File[]) => void;
@@ -33,16 +35,21 @@ const FileUpload: FC<FileUploadProps> = ({
   description,
   constraintText,
   secondaryControl,
-  errorText,
   info,
   buttonText = 'Choose file',
   name,
   accept,
   files,
+  sizeLimit,
   onChange,
   ...props
 }) => {
   const inputElement = useRef<HTMLInputElement | null>(null);
+  const [errorText, setErrorText] = useState<React.ReactNode>(props.errorText);
+
+  useEffect(() => {
+    setErrorText(props.errorText);
+  }, [props.errorText]);
 
   const footer = useMemo(() => {
     if (!files || files.length === 0) {
@@ -64,6 +71,7 @@ const FileUpload: FC<FileUploadProps> = ({
   const handleFileSelectionChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
     (event) => {
       const newFiles: File[] = [];
+      setErrorText(undefined);
 
       if (event.target.files) {
         const targetFiles = event.target.files;
@@ -71,6 +79,11 @@ const FileUpload: FC<FileUploadProps> = ({
         for (let i = 0; i < len; i++) {
           const file = targetFiles.item(i);
           if (file) {
+            if (sizeLimit && file.size > sizeLimit) {
+              setErrorText(`File ${file.name} exceeds maximum file size limit: ${getDisplaySize(sizeLimit)}`);
+              break;
+            }
+
             newFiles.push(file);
           }
         }

--- a/packages/threat-composer/src/components/generic/FileUpload/utils/getDisplaySize/index.ts
+++ b/packages/threat-composer/src/components/generic/FileUpload/utils/getDisplaySize/index.ts
@@ -22,7 +22,7 @@ const getDisplaySize = (size?: number | null) => {
 
   const i = Math.floor(Math.log(size) / Math.log(k));
 
-  return `Size: ${parseFloat((size / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+  return `${parseFloat((size / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 };
 
 export default getDisplaySize;

--- a/packages/threat-composer/src/components/generic/ImageEdit/index.tsx
+++ b/packages/threat-composer/src/components/generic/ImageEdit/index.tsx
@@ -20,11 +20,13 @@ import RadioGroup from '@cloudscape-design/components/radio-group';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import imageCompression from 'browser-image-compression';
 import { FC, useCallback, useEffect, useState } from 'react';
+import { IMAGE_UPLOAD_MAX_SIZE } from '../../../configs';
 import { ImageUrlSchema } from '../../../customTypes';
 import imageStyles from '../../../styles/image';
 import getBase64 from '../../../utils/getBase64';
 import Input from '../../generic/Input';
 import FileUpload from '../FileUpload';
+import getDisplaySize from '../FileUpload/utils/getDisplaySize';
 
 export interface ImageUploadProps {
   value: string;
@@ -100,7 +102,9 @@ const ImageEdit: FC<ImageUploadProps> = ({
       <FileUpload
         key='fileUpload'
         label='Image Upload'
+        constraintText={`Maximum file size: ${getDisplaySize(IMAGE_UPLOAD_MAX_SIZE)}`}
         accept='image/png, image/gif, image/jpeg'
+        sizeLimit={IMAGE_UPLOAD_MAX_SIZE}
         files={selectedFiles}
         onChange={handleChange} />
     </SpaceBetween>

--- a/packages/threat-composer/src/components/generic/ImageEdit/index.tsx
+++ b/packages/threat-composer/src/components/generic/ImageEdit/index.tsx
@@ -20,19 +20,17 @@ import RadioGroup from '@cloudscape-design/components/radio-group';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import imageCompression from 'browser-image-compression';
 import { FC, useCallback, useEffect, useState } from 'react';
-import { IMAGE_UPLOAD_MAX_SIZE } from '../../../configs';
+import { IMAGE_BASE64_MAX_LENGTH } from '../../../configs';
 import { ImageUrlSchema } from '../../../customTypes';
 import imageStyles from '../../../styles/image';
 import getBase64 from '../../../utils/getBase64';
 import Input from '../../generic/Input';
 import FileUpload from '../FileUpload';
-import getDisplaySize from '../FileUpload/utils/getDisplaySize';
 
 export interface ImageUploadProps {
   value: string;
   onChange: (value: string) => void;
 }
-
 
 const ImageEdit: FC<ImageUploadProps> = ({
   value,
@@ -43,6 +41,7 @@ const ImageEdit: FC<ImageUploadProps> = ({
   const [inputValue, setInputValue] = useState(isValueBase64String ? '' : value);
   const [imageSource, setImageSource] = useState<string>(!value ? 'no' : isValueBase64String ? 'file' : 'url');
   const [image, setImage] = useState<string>(isValueBase64String ? value : '');
+  const [errorText, setErrorText] = useState<string>();
 
   useEffect(() => {
     if (imageSource === 'no') {
@@ -73,9 +72,14 @@ const ImageEdit: FC<ImageUploadProps> = ({
 
   const handleChange = useCallback(async (_selectedFiles: File[]) => {
     setSelectedFiles(_selectedFiles);
+    setErrorText(undefined);
     if (_selectedFiles.length > 0) {
       const _image = await handleImageUpload(_selectedFiles[0]);
-      setImage(_image || '');
+      if (_image.length > IMAGE_BASE64_MAX_LENGTH) {
+        setErrorText('Image size limit exceeded');
+      } else {
+        setImage(_image || '');
+      }
     }
   }, []);
 
@@ -102,9 +106,8 @@ const ImageEdit: FC<ImageUploadProps> = ({
       <FileUpload
         key='fileUpload'
         label='Image Upload'
-        constraintText={`Maximum file size: ${getDisplaySize(IMAGE_UPLOAD_MAX_SIZE)}`}
         accept='image/png, image/gif, image/jpeg'
-        sizeLimit={IMAGE_UPLOAD_MAX_SIZE}
+        errorText={errorText}
         files={selectedFiles}
         onChange={handleChange} />
     </SpaceBetween>

--- a/packages/threat-composer/src/configs/constants.ts
+++ b/packages/threat-composer/src/configs/constants.ts
@@ -31,7 +31,9 @@ export const FREE_TEXT_INPUT_SMALL_MAX_LENGTH = 1000;
 // Application info, Architecture description, Dataflow description
 export const FREE_TEXT_INPUT_MAX_LENGTH = 100000;
 // Architecture diagram, data flow diagram
-export const IMAGE_BASE64_MAX_LENGTH = 500000;
+export const IMAGE_BASE64_MAX_LENGTH = 2000000;
+// Architecture diagram, data flow diagram max upload size
+export const IMAGE_UPLOAD_MAX_SIZE = 1000 * 1000;
 //  Architecture diagram url, data flow diagram, url
 export const IMAGE_URL_MAX_LENGTH = 2048;
 

--- a/packages/threat-composer/src/configs/constants.ts
+++ b/packages/threat-composer/src/configs/constants.ts
@@ -31,9 +31,7 @@ export const FREE_TEXT_INPUT_SMALL_MAX_LENGTH = 1000;
 // Application info, Architecture description, Dataflow description
 export const FREE_TEXT_INPUT_MAX_LENGTH = 100000;
 // Architecture diagram, data flow diagram
-export const IMAGE_BASE64_MAX_LENGTH = 2000000;
-// Architecture diagram, data flow diagram max upload size
-export const IMAGE_UPLOAD_MAX_SIZE = 1000 * 1000;
+export const IMAGE_BASE64_MAX_LENGTH = 1000000;
 //  Architecture diagram url, data flow diagram, url
 export const IMAGE_URL_MAX_LENGTH = 2048;
 


### PR DESCRIPTION
*Issue #, if available:*

#62 

*Description of changes:*

Currently, we have set the image base64 size limit to 500000 to encourage users to upload smaller size images because of very limited local storage space. However, when users upload an image file with more that 500K, we do not show the error message until users export and reimport the json file. The validation failed. 

The PR is to increase the file size limit and also show the error message. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
