### PR TITLE
feat(ClientSideAPI): Add API ready property

### DIFF
--- a/packages/threat-composer/src/components/generic/WindowExporter/index.tsx
+++ b/packages/threat-composer/src/components/generic/WindowExporter/index.tsx
@@ -43,6 +43,7 @@ window.threatcomposer = {
     Promise.resolve(PLACEHOLDER_EXCHANGE_DATA_FOR_WORKSPACE),
   deleteWorkspace: () => Promise.resolve(),
   renameWorkspace: () => Promise.resolve(),
+  apiReady: false,
 };
 
 /**
@@ -69,35 +70,23 @@ const WindowExporter: FC<PropsWithChildren<{}>> = ({ children }) => {
 
   useEffect(() => {
     window.threatcomposer.getWorkspaceList = () => workspaceList;
-  }, [workspaceList]);
-
-  useEffect(() => {
     window.threatcomposer.getCurrentWorkspaceMetadata = () => currentWorkspace;
-  }, [currentWorkspace]);
-
-  useEffect(() => {
     window.threatcomposer.getCurrentWorkspaceData = getWorkspaceData;
-  }, [getWorkspaceData]);
-
-  useEffect(() => {
     window.threatcomposer.setCurrentWorkspaceData = setWorkspaceData;
-  }, [setWorkspaceData]);
-
-  useEffect(() => {
     window.threatcomposer.createWorkspace = addWorkspace;
-  }, [addWorkspace]);
-
-  useEffect(() => {
     window.threatcomposer.deleteWorkspace = deleteWorkspace;
-  }, [deleteWorkspace]);
-
-  useEffect(() => {
     window.threatcomposer.switchWorkspace = switchWorkspace;
-  }, [switchWorkspace]);
-
-  useEffect(() => {
     window.threatcomposer.renameWorkspace = renameWorkspace;
-  }, [renameWorkspace]);
+    window.threatcomposer.apiReady = true;
+  }, [
+    workspaceList,
+    currentWorkspace,
+    getWorkspaceData,
+    addWorkspace,
+    deleteWorkspace,
+    switchWorkspace,
+    renameWorkspace,
+  ]);
 
   return <>{children}</>;
 };

--- a/packages/threat-composer/src/customTypes/dataExchange.ts
+++ b/packages/threat-composer/src/customTypes/dataExchange.ts
@@ -72,4 +72,5 @@ export interface ThreatComposerNamespace {
     metadata?: Workspace['metadata']) => Promise<Workspace>;
   deleteWorkspace: (id: string) => Promise<void>;
   renameWorkspace: (id: string, newWorkspaceName: string) => Promise<void>;
+  apiReady: boolean;
 }


### PR DESCRIPTION
Related to existing merged PR [ClientSideAPI](https://github.com/awslabs/threat-composer/pull/55) this PR implements a new property called `apiReady` (`boolean`) for consumers of the client-side API to verify that the API is loaded and ready to be used, else can lead to a condition where API functions are called prior to being ready and hence are not functional.