### PR TITLE
fix: Spelling of "priority" in dropdown

### DIFF
--- a/packages/threat-composer/src/components/threats/PriorityEdit/index.tsx
+++ b/packages/threat-composer/src/components/threats/PriorityEdit/index.tsx
@@ -42,7 +42,7 @@ const PriorityEdit: FC<PriorityEditProps> = React.forwardRef<React.ForwardedRef<
       ref={ref}
       {...props}
       allowNoValue
-      placeholder='Select Prority'
+      placeholder='Select Priority'
       label={showLabel ? 'Priority' : undefined}
       selectedLevel={priority}
       setSelectedLevel={(selectedLevel) => onEditMetadata(editingStatement, 'Priority', selectedLevel)}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing a minor spelling mistake in "Select Priority" dropdown.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
