### PR TITLE
feat: Support other image formats for architecture diagrams and dataflow diagrams. Close #84

### DIFF
--- a/packages/threat-composer/src/components/generic/ImageEdit/index.tsx
+++ b/packages/threat-composer/src/components/generic/ImageEdit/index.tsx
@@ -32,6 +32,18 @@ export interface ImageUploadProps {
   onChange: (value: string) => void;
 }
 
+const IMAGE_COMPRESSION_OPTIONS = {
+  maxSizeMB: 0.5,
+  maxWidthOrHeight: 1024,
+  useWebWorker: true,
+};
+
+const IMAGE_COMPRESSION_TYPES = [
+  'image/png',
+  'image/gif',
+  'image/jpeg',
+];
+
 const ImageEdit: FC<ImageUploadProps> = ({
   value,
   onChange,
@@ -54,16 +66,15 @@ const ImageEdit: FC<ImageUploadProps> = ({
   }, [onChange, imageSource, image, inputValue]);
 
   const handleImageUpload = useCallback(async (imageFile: File) => {
-    const options = {
-      maxSizeMB: 0.5,
-      maxWidthOrHeight: 1024,
-      useWebWorker: true,
-    };
-
     try {
-      const compressedFile = await imageCompression(imageFile, options);
-      const base64String = await getBase64(compressedFile);
-      return base64String;
+      // Compress the image if it is supported by browser-image-compression
+      if (IMAGE_COMPRESSION_TYPES.includes(imageFile.type)) {
+        const compressedFile = await imageCompression(imageFile, IMAGE_COMPRESSION_OPTIONS);
+        const base64String = await getBase64(compressedFile);
+        return base64String;
+      }
+
+      return await getBase64(imageFile);
     } catch (error) {
       console.log(error);
       return '';
@@ -106,7 +117,7 @@ const ImageEdit: FC<ImageUploadProps> = ({
       <FileUpload
         key='fileUpload'
         label='Image Upload'
-        accept='image/png, image/gif, image/jpeg'
+        accept='image/*'
         errorText={errorText}
         files={selectedFiles}
         onChange={handleChange} />


### PR DESCRIPTION

*Issue #, if available:*

#84 

*Description of changes:*

Allow all image formats (image/*) upload for architecture diagrams and dataflow diagrams. For 'image/png', 'image/gif', or 'image/jpeg', run the browser-image-compression plugin; for other images, keep the original format. The total number bytes of the resulted base64 encoded image is checked to ensure it is less than 1MB. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
