### PR TITLE
chore(Browser extension): Remove reload of threat model on visibility

### DIFF
--- a/packages/threat-composer-app-browser-extension/src/entrypoints/background.ts
+++ b/packages/threat-composer-app-browser-extension/src/entrypoints/background.ts
@@ -24,18 +24,14 @@ export default defineBackground(() => {
 
     getExtensionConfig().then(config => {
       const tcViewer = config.target;
-      let tcUrlCreate = '';
-      let tcUrlUpdate = '';
+      let tcUrl = '';
 
       if (tcViewer == ThreatComposerTarget.BUILT_IN) {
-        tcUrlCreate = browser.runtime.getURL('index.html');
-        tcUrlUpdate = browser.runtime.getURL('*');
+        tcUrl = browser.runtime.getURL('');
       } else if (tcViewer == ThreatComposerTarget.GITHUB_PAGES) {
-        tcUrlCreate = 'https://awslabs.github.io/threat-composer';
-        tcUrlUpdate = tcUrlCreate;
+        tcUrl = 'https://awslabs.github.io/threat-composer';
       } else if (tcViewer == ThreatComposerTarget.CUSTOM_HOST) {
-        tcUrlCreate = config.customUrl ?? '';
-        tcUrlUpdate = tcUrlCreate;
+        tcUrl = config.customUrl ?? '';
       }
 
       if (request.schema) { //This is likely the JSON from a threat model
@@ -45,11 +41,11 @@ export default defineBackground(() => {
           logDebugMessage(config, 'Saved to browser storage');
         });
 
-        browser.tabs.query({ url: tcUrlUpdate }).then((tabs: any) => {
+        browser.tabs.query({ url: tcUrl + '*' }).then((tabs: any) => {
           if (tabs.length > 0) {
-            browser.tabs.update(tabs[0].id, { active: true });
+            browser.tabs.update(tabs[0].id, { active: true, url: tcUrl + 'index.html' });
           } else {
-            browser.tabs.create({ url: tcUrlCreate });
+            browser.tabs.create({ url: tcUrl + 'index.html' });
           }
         });
         sendResponse({});

--- a/packages/threat-composer-app-browser-extension/src/public/scriptInjectForThreatComposer.js
+++ b/packages/threat-composer-app-browser-extension/src/public/scriptInjectForThreatComposer.js
@@ -69,10 +69,6 @@ logDebugMessage(
   "Adding DOMContentLoaded and visibility event listener to trigger load of threat model"
 );
 
-document.addEventListener("visibilitychange", (event) => {
-  loadThreatModel("visibilitychange");
-});
-
 async function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);

--- a/packages/threat-composer-app-browser-extension/wxt.config.ts
+++ b/packages/threat-composer-app-browser-extension/wxt.config.ts
@@ -9,7 +9,7 @@ function generateManifest(env: ConfigEnv): UserManifest {
   const manifest: UserManifest = {
     name: 'Threat Composer Viewer',
     description: "View a Threat Composer JSON export in Threat Composer",
-    version_name: "0.0.3-alpha",
+    version_name: "0.0.4-alpha",
     content_scripts: [
       {
         matches: ["*://*/*.tc.json*", "*://*.github.com/*"],


### PR DESCRIPTION
Change threat model reload behaviour to no longer reload the threat model on visibility changes of the window/tab, as it would result in overwriting any unexported changes a user has performed.