### PR TITLE
fix: Fix the dark theme in ThreatModel Print Preview page

### DIFF
--- a/packages/threat-composer-app/.projen/deps.json
+++ b/packages/threat-composer-app/.projen/deps.json
@@ -114,6 +114,10 @@
       "type": "runtime"
     },
     {
+      "name": "@emotion/react",
+      "type": "runtime"
+    },
+    {
       "name": "@uidotdev/usehooks",
       "type": "runtime"
     },

--- a/packages/threat-composer-app/.projen/tasks.json
+++ b/packages/threat-composer-app/.projen/tasks.json
@@ -145,13 +145,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@cloudscape-design/jest-preset,@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,@types/jest,@types/react,@types/react-dom,@types/react-router-dom,@types/uuid,eslint-import-resolver-typescript,eslint-plugin-import,merge,@aws-northstar/ui,@aws/threat-composer,@cloudscape-design/components,@cloudscape-design/design-tokens,@cloudscape-design/global-styles,@uidotdev/usehooks,docx,react,react-dom,react-router-dom,unist-util-visit,uuid,web-vitals"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@cloudscape-design/jest-preset,@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,@types/jest,@types/react,@types/react-dom,@types/react-router-dom,@types/uuid,eslint-import-resolver-typescript,eslint-plugin-import,merge,@aws-northstar/ui,@aws/threat-composer,@cloudscape-design/components,@cloudscape-design/design-tokens,@cloudscape-design/global-styles,@emotion/react,@uidotdev/usehooks,docx,react,react-dom,react-router-dom,unist-util-visit,uuid,web-vitals"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @cloudscape-design/jest-preset @testing-library/jest-dom @testing-library/react @testing-library/user-event @types/jest @types/node @types/react @types/react-dom @types/react-router-dom @types/uuid @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-typescript eslint-plugin-import eslint merge projen typescript @aws-northstar/ui @aws/threat-composer @cloudscape-design/components @cloudscape-design/design-tokens @cloudscape-design/global-styles @uidotdev/usehooks docx react react-dom react-router-dom react-scripts remark-frontmatter remark-gfm remark-parse unified unist-util-visit uuid web-vitals"
+          "exec": "yarn upgrade @cloudscape-design/jest-preset @testing-library/jest-dom @testing-library/react @testing-library/user-event @types/jest @types/node @types/react @types/react-dom @types/react-router-dom @types/uuid @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-typescript eslint-plugin-import eslint merge projen typescript @aws-northstar/ui @aws/threat-composer @cloudscape-design/components @cloudscape-design/design-tokens @cloudscape-design/global-styles @emotion/react @uidotdev/usehooks docx react react-dom react-router-dom react-scripts remark-frontmatter remark-gfm remark-parse unified unist-util-visit uuid web-vitals"
         },
         {
           "exec": "npx projen"

--- a/packages/threat-composer-app/package.json
+++ b/packages/threat-composer-app/package.json
@@ -44,6 +44,7 @@
     "@cloudscape-design/components": "^3.0.517",
     "@cloudscape-design/design-tokens": "^3.0.34",
     "@cloudscape-design/global-styles": "^1.0.23",
+    "@emotion/react": "^11.11.4",
     "@uidotdev/usehooks": "^2.4.1",
     "docx": "^8.5.0",
     "react": "^18.2.0",

--- a/packages/threat-composer-app/src/containers/ThreatModelPreview/index.tsx
+++ b/packages/threat-composer-app/src/containers/ThreatModelPreview/index.tsx
@@ -13,10 +13,26 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
+/** @jsxImportSource @emotion/react */
 import { ThreatModelView } from '@aws/threat-composer';
-import Box from '@cloudscape-design/components/box';
+import { Container } from '@cloudscape-design/components';
+import * as awsui from '@cloudscape-design/design-tokens';
+import { css } from '@emotion/react';
 import { FC, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+
+const styles = {
+  container: css({
+    'background': awsui.colorBackgroundContainerContent,
+    'width': '100vw',
+    'height': '100vh',
+    '&>div': {
+      border: 'none !important',
+      borderRadius: '0px !important',
+      boxShadow: 'none !important',
+    },
+  }),
+};
 
 const ThreatModelPreview: FC = () => {
   const { dataKey } = useParams();
@@ -37,11 +53,11 @@ const ThreatModelPreview: FC = () => {
     };
   }, [dataKey]);
 
-  if (!data) {
-    return <Box>No content</Box>;
-  }
-
-  return <ThreatModelView composerMode='Full' data={data} isPreview />;
+  return (<div css={styles.container}>
+    <Container>
+      {data ? <ThreatModelView composerMode='Full' data={data} isPreview /> : <div>No content</div>}
+    </Container>
+  </div>);
 };
 
 export default ThreatModelPreview;

--- a/packages/threat-composer/src/components/generic/ThemeToggle/index.tsx
+++ b/packages/threat-composer/src/components/generic/ThemeToggle/index.tsx
@@ -22,11 +22,6 @@ import { css } from '@emotion/react';
 import { useThemeContext } from '../ThemeProvider';
 
 const styles = {
-  container: css({
-    height: '100%',
-    display: 'flex',
-    alignItems: 'center',
-  }),
   svg: css({
     color: 'grey !important',
     fill: 'grey !important',
@@ -35,7 +30,7 @@ const styles = {
 
 const ThemeToggle = () => {
   const { theme, setTheme } = useThemeContext();
-  return (<div css={styles.container}>
+  return (<div>
     <SpaceBetween direction="horizontal" size="xs">
       <Toggle
         onChange={({ detail }) =>

--- a/packages/threat-composer/src/components/workspaces/WorkspaceSelector/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceSelector/index.tsx
@@ -52,6 +52,9 @@ import FileImport from '../../workspaces/FileImport';
 
 const styles = {
   themeToggle: css({
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
     [getMobileMediaQuery()]: {
       display: 'none',
     },

--- a/packages/threat-composer/src/components/workspaces/WorkspaceSelector/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceSelector/index.tsx
@@ -13,6 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
+/** @jsxImportSource @emotion/react */
+
 import DeleteConfirmationDialog from '@aws-northstar/ui/components/DeleteConfirmationDialog';
 import Alert from '@cloudscape-design/components/alert';
 import Button from '@cloudscape-design/components/button';
@@ -25,6 +27,7 @@ import {
 } from '@cloudscape-design/components/internal/events';
 import Select, { SelectProps } from '@cloudscape-design/components/select';
 import SpaceBetween from '@cloudscape-design/components/space-between';
+import { css } from '@emotion/react';
 import { FC, useMemo, useState, useCallback, PropsWithChildren } from 'react';
 import { APP_MODE_IDE_EXTENSION } from '../../../configs';
 import {
@@ -41,10 +44,19 @@ import {
 } from '../../../customTypes';
 import useImportExport from '../../../hooks/useExportImport';
 import useRemoveData from '../../../hooks/useRemoveData';
+import getMobileMediaQuery from '../../../utils/getMobileMediaQuery';
 import isWorkspaceExample from '../../../utils/isWorkspaceExample';
 import ThemeToggle from '../../generic/ThemeToggle';
 import EditWorkspace from '../../workspaces/EditWorkspace';
 import FileImport from '../../workspaces/FileImport';
+
+const styles = {
+  themeToggle: css({
+    [getMobileMediaQuery()]: {
+      display: 'none',
+    },
+  }),
+};
 
 export interface WorkspaceSelectorProps {
   embededMode: boolean;
@@ -360,7 +372,7 @@ const WorkspaceSelector: FC<PropsWithChildren<WorkspaceSelectorProps>> = ({
             onItemClick={handleMoreActions}
           />
         )}
-        {appMode !== 'ide-extension' && composerMode === 'Full' && <ThemeToggle />}
+        {appMode !== 'ide-extension' && composerMode === 'Full' && <div css={styles.themeToggle}><ThemeToggle /></div>}
       </SpaceBetween>
       {fileImportModalVisible && (
         <FileImport

--- a/projenrc/app.ts
+++ b/projenrc/app.ts
@@ -15,6 +15,7 @@ class ThreatComposerReactAppProject extends ReactTypeScriptProject {
         "@cloudscape-design/global-styles",
         "@cloudscape-design/design-tokens",
         "@aws-northstar/ui",
+        "@emotion/react",
         "@uidotdev/usehooks",
         "react-router-dom",
         "uuid",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3454,6 +3454,20 @@
     "@emotion/weak-memoize" "^0.3.1"
     hoist-non-react-statics "^3.3.1"
 
+"@emotion/react@^11.11.4":
+  version "11.11.4"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.11.4.tgz#3a829cac25c1f00e126408fab7f891f00ecc3c1d"
+  integrity sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.11.0"
+    "@emotion/cache" "^11.11.0"
+    "@emotion/serialize" "^1.1.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
+    "@emotion/utils" "^1.2.1"
+    "@emotion/weak-memoize" "^0.3.1"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/serialize@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.2.tgz#017a6e4c9b8a803bd576ff3d52a0ea6fa5a62b51"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR is to fix the dark theme for the ThreatModel Print Preview Page. And also hide the theme toggle on Mobile pages since there is no enough space when the workspace name is long. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
