### PR TITLE
feat: Multi-stage build Dockerfile for building and serving threat composer. Close #97

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM public.ecr.aws/p9i6h6j0/aws-pdk:latest as build
+
+#install dependencies
+RUN dnf -y install rsync
+
+# Create a non-root user named 'app' and set up home directory
+RUN useradd -m app
+
+# Create an app directory and change its ownership to the 'app' user
+RUN mkdir /app && chown app:app /app
+
+# Switch to the 'app' user
+USER app
+
+# Set the working directory to the app directory
+WORKDIR /app
+
+#Copy files into the Docker image
+COPY --chown=app:app . .
+RUN ./scripts/build.sh
+
+# Stage 2: Serve the application using Nginx
+FROM nginx:alpine
+# Remove the default nginx website
+RUN rm -rf /usr/share/nginx/html/*
+# Copy the build output to the nginx html directory
+COPY --from=build /app/packages/threat-composer-app/build/website/ /usr/share/nginx/html
+# Copy custom nginx configuration if any
+#iCOPY nginx.conf /etc/nginx/nginx.conf
+# Expose port 80
+EXPOSE 80
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,6 @@ FROM nginx:alpine
 RUN rm -rf /usr/share/nginx/html/*
 # Copy the build output to the nginx html directory
 COPY --from=build /app/packages/threat-composer-app/build/website/ /usr/share/nginx/html
-# Copy custom nginx configuration if any
-#iCOPY nginx.conf /etc/nginx/nginx.conf
 # Expose port 80
 EXPOSE 80
 # Start nginx


### PR DESCRIPTION
…ode from checkout and subsequently copies the website folder into a second stage image that runs the website via nginx

*Issue #97 :* 

*Description of changes:*
Adds a two-stage docker container that builds a container to build the code and run the application containerized. The container uses the aws-pdk container image to build the first stage and the alpine-nginx to serve the application. 

Note that serving happens by default on 80. We assume that the image is run locally over a laptop. If additional SSL/TLS implementation is required it must be done by the user at the loadbalancer level. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
