### PR TITLE
feat: Allow users to set status for mitigations and threats. Close #61. Close #126

### DIFF
--- a/packages/threat-composer-app/src/containers/MitigationList/index.tsx
+++ b/packages/threat-composer-app/src/containers/MitigationList/index.tsx
@@ -14,9 +14,13 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import { MitigationList as MitigationListComponent } from '@aws/threat-composer';
+import { useLocation } from 'react-router-dom';
 
 const MitigationList = () => {
-  return <MitigationListComponent />;
+  const { state } = useLocation();
+  return <MitigationListComponent
+    initialFilter={state?.filter}
+  />;
 };
 
 export default MitigationList;

--- a/packages/threat-composer-app/src/containers/WorkspaceHome/index.tsx
+++ b/packages/threat-composer-app/src/containers/WorkspaceHome/index.tsx
@@ -13,8 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import { WorkspaceHome as WorkspaceHomeComponent, ThreatStatementListFilter } from '@aws/threat-composer';
-import { ROUTE_APPLICATION_INFO, ROUTE_THREAT_EDITOR, ROUTE_THREAT_LIST } from '../../config/routes';
+import { WorkspaceHome as WorkspaceHomeComponent, ThreatStatementListFilter, MitigationListFilter } from '@aws/threat-composer';
+import { ROUTE_APPLICATION_INFO, ROUTE_MITIGATION_LIST, ROUTE_THREAT_EDITOR, ROUTE_THREAT_LIST } from '../../config/routes';
 import useNavigateView from '../../hooks/useNavigationView';
 
 const WorkspaceHome = () => {
@@ -29,6 +29,11 @@ const WorkspaceHome = () => {
       },
     })}
     onThreatListView={(filter?: ThreatStatementListFilter) => handleNavigateView(ROUTE_THREAT_LIST, undefined, undefined, undefined, {
+      state: filter ? {
+        filter,
+      } : undefined,
+    })}
+    onMitigationListView={(filter?: MitigationListFilter) => handleNavigateView(ROUTE_MITIGATION_LIST, undefined, undefined, undefined, {
       state: filter ? {
         filter,
       } : undefined,

--- a/packages/threat-composer-app/src/utils/convertToDocx/getMitigations.ts
+++ b/packages/threat-composer-app/src/utils/convertToDocx/getMitigations.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import { Mitigation, MitigationLink, AssumptionLink, DataExchangeFormat, standardizeNumericId } from '@aws/threat-composer';
+import { Mitigation, MitigationLink, AssumptionLink, DataExchangeFormat, standardizeNumericId, mitigationStatus, STATUS_NOT_SET } from '@aws/threat-composer';
 import { Paragraph, HeadingLevel, TextRun, TableCell, TableRow } from 'docx';
 import Table from './components/Table';
 import getAnchorLink from './getAnchorLink';
@@ -64,7 +64,7 @@ const getDataRow = async (mitigation: Mitigation, data: DataExchangeFormat) => {
   const mitigationId = `M-${standardizeNumericId(mitigation.numericId)}`;
   const threatLinks = data.mitigationLinks?.filter(ml => ml.mitigationId === mitigation.id) || [];
   const assumptionLinks = data.assumptionLinks?.filter(al => al.linkedId === mitigation.id) || [];
-
+  const status = (mitigation.status && mitigationStatus.find(ms => ms.value === mitigation.status)?.label) || STATUS_NOT_SET;
   const renderedComents = await renderComment(mitigation.metadata);
 
   const tableRow = new TableRow({
@@ -81,6 +81,9 @@ const getDataRow = async (mitigation: Mitigation, data: DataExchangeFormat) => {
       }),
       getThreatLinksCell(threatLinks, data),
       getAssumptionLinksCell(assumptionLinks, data),
+      new TableCell({
+        children: [new Paragraph(status)],
+      }),
       new TableCell({
         children: renderedComents,
       }),
@@ -111,7 +114,7 @@ const getMitigations = async (
 
   const table = new Table({
     rows: [
-      getHeaderRow(['Mitigation Number', 'Mitigation', 'Threats Mitigating', 'Assumptions', 'Comments']),
+      getHeaderRow(['Mitigation Number', 'Mitigation', 'Threats Mitigating', 'Assumptions', 'Status', 'Comments']),
       ...dataRows,
     ],
   });

--- a/packages/threat-composer-app/src/utils/convertToDocx/getThreats.ts
+++ b/packages/threat-composer-app/src/utils/convertToDocx/getThreats.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import { AssumptionLink, DataExchangeFormat, MitigationLink, TemplateThreatStatement, standardizeNumericId } from '@aws/threat-composer';
+import { AssumptionLink, DataExchangeFormat, MitigationLink, TemplateThreatStatement, standardizeNumericId, threatStatus, STATUS_NOT_SET } from '@aws/threat-composer';
 import { Paragraph, HeadingLevel, TextRun, TableRow, TableCell } from 'docx';
 import Table from './components/Table';
 import getAnchorLink from './getAnchorLink';
@@ -64,6 +64,7 @@ const getDataRow = async (threat: TemplateThreatStatement, data: DataExchangeFor
   const assumptionLinks = data.assumptionLinks?.filter(al => al.linkedId === threat.id) || [];
   const threatId = `T-${standardizeNumericId(threat.numericId)}`;
   const comments = await renderComment(threat.metadata);
+  const status = (threat.status && threatStatus.find(x => x.value === threat.status)?.label) || STATUS_NOT_SET;
   const priority = threat.metadata?.find(m => m.key === 'Priority')?.value as string || '';
   const STRIDE = ((threat.metadata?.find(m => m.key === 'STRIDE')?.value || []) as string[]).join(', ');
 
@@ -81,6 +82,9 @@ const getDataRow = async (threat: TemplateThreatStatement, data: DataExchangeFor
       }),
       getMitigationLinksCell(mitigationLinks, data),
       getAssumptionLinksCell(assumptionLinks, data),
+      new TableCell({
+        children: [new Paragraph(status)],
+      }),
       new TableCell({
         children: [new Paragraph(priority)],
       }),
@@ -119,8 +123,8 @@ const getThreats = async (
   const table = new Table({
     rows: [
       getHeaderRow(
-        threatsOnly ? ['Threat Number', 'Threat', 'Comments', 'Priority', 'STRIDE', 'Comments']
-          : ['Threat Number', 'Threat', 'Mitigations', 'Assumptions', 'Priority', 'STRIDE', 'Comments']),
+        threatsOnly ? ['Threat Number', 'Threat', 'Status', 'Priority', 'STRIDE', 'Comments']
+          : ['Threat Number', 'Threat', 'Mitigations', 'Assumptions', 'Status', 'Priority', 'STRIDE', 'Comments']),
       ...dataRows,
     ],
   });

--- a/packages/threat-composer/src/components/assumptions/AssumptionCreationCard/index.tsx
+++ b/packages/threat-composer/src/components/assumptions/AssumptionCreationCard/index.tsx
@@ -15,10 +15,10 @@
  ******************************************************************************************************************** */
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { FC, useState, useCallback } from 'react';
-import { DEFAULT_NEW_ENTITY_ID } from '../../../configs';
 import { useMitigationsContext } from '../../../contexts/MitigationsContext/context';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
 import { Assumption, AssumptionSchema } from '../../../customTypes';
+import getNewMitigation from '../../../utils/getNewMitigation';
 import GenericEntityCreationCard, { DEFAULT_ENTITY } from '../../generic/GenericEntityCreationCard';
 import MitigationLinkView from '../../mitigations/MitigationLinkView';
 import ThreatLinkView from '../../threats/ThreatLinkView';
@@ -52,11 +52,7 @@ const AssumptionCreationCard: FC<AssumptionCreationCardProps> = ({ onSave }) => 
     if (mitigationList.find(m => m.id === mitigationIdOrNewMitigation)) {
       setLinkedMitigationIds(prev => [...prev, mitigationIdOrNewMitigation]);
     } else {
-      const newMitigation = saveMitigation({
-        numericId: -1,
-        content: mitigationIdOrNewMitigation,
-        id: DEFAULT_NEW_ENTITY_ID,
-      });
+      const newMitigation = saveMitigation(getNewMitigation(mitigationIdOrNewMitigation));
       setLinkedMitigationIds(prev => [...prev, newMitigation.id]);
     }
   }, [mitigationList, saveMitigation]);

--- a/packages/threat-composer/src/components/assumptions/AssumptionCreationCard/index.tsx
+++ b/packages/threat-composer/src/components/assumptions/AssumptionCreationCard/index.tsx
@@ -18,8 +18,9 @@ import { FC, useState, useCallback } from 'react';
 import { useMitigationsContext } from '../../../contexts/MitigationsContext/context';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
 import { Assumption, AssumptionSchema } from '../../../customTypes';
+import getNewAssumption from '../../../utils/getNewAssumption';
 import getNewMitigation from '../../../utils/getNewMitigation';
-import GenericEntityCreationCard, { DEFAULT_ENTITY } from '../../generic/GenericEntityCreationCard';
+import GenericEntityCreationCard from '../../generic/GenericEntityCreationCard';
 import MitigationLinkView from '../../mitigations/MitigationLinkView';
 import ThreatLinkView from '../../threats/ThreatLinkView';
 
@@ -28,7 +29,7 @@ export interface AssumptionCreationCardProps {
 }
 
 const AssumptionCreationCard: FC<AssumptionCreationCardProps> = ({ onSave }) => {
-  const [editingEntity, setEditingEntity] = useState<Assumption>(DEFAULT_ENTITY);
+  const [editingEntity, setEditingEntity] = useState<Assumption>(getNewAssumption());
   const [linkedMitigationIds, setLinkedMitigationIds] = useState<string[]>([]);
   const [linkedThreatIds, setLinkedThreatIds] = useState<string[]>([]);
 
@@ -37,13 +38,13 @@ const AssumptionCreationCard: FC<AssumptionCreationCardProps> = ({ onSave }) => 
 
   const handleSave = useCallback(() => {
     onSave?.(editingEntity, linkedMitigationIds, linkedThreatIds);
-    setEditingEntity(DEFAULT_ENTITY);
+    setEditingEntity(getNewAssumption());
     setLinkedMitigationIds([]);
     setLinkedThreatIds([]);
   }, [editingEntity, linkedMitigationIds, linkedThreatIds]);
 
   const handleReset = useCallback(() => {
-    setEditingEntity(DEFAULT_ENTITY);
+    setEditingEntity(getNewAssumption());
     setLinkedMitigationIds([]);
     setLinkedThreatIds([]);
   }, []);

--- a/packages/threat-composer/src/components/assumptions/AssumptionMitigationLink/index.tsx
+++ b/packages/threat-composer/src/components/assumptions/AssumptionMitigationLink/index.tsx
@@ -14,10 +14,10 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import { FC, useCallback, useEffect, useState } from 'react';
-import { DEFAULT_NEW_ENTITY_ID } from '../../../configs';
 import { useAssumptionLinksContext } from '../../../contexts/AssumptionLinksContext/context';
 import { useMitigationsContext } from '../../../contexts/MitigationsContext/context';
 import { AssumptionLink } from '../../../customTypes';
+import getNewMitigation from '../../../utils/getNewMitigation';
 import MitigationLinkView from '../../mitigations/MitigationLinkView';
 
 export interface AssumptionThreatLinkProps {
@@ -50,11 +50,7 @@ const AssumptionThreatLinkComponent: FC<AssumptionThreatLinkProps> = ({
         type: 'Mitigation',
       });
     } else {
-      const newMitigation = saveMitigation({
-        numericId: -1,
-        content: mitigationIdOrNewMitigation,
-        id: DEFAULT_NEW_ENTITY_ID,
-      });
+      const newMitigation = saveMitigation(getNewMitigation(mitigationIdOrNewMitigation));
       addAssumptionLink({
         type: 'Mitigation',
         linkedId: newMitigation.id,

--- a/packages/threat-composer/src/components/generic/DashboardNumber/index.tsx
+++ b/packages/threat-composer/src/components/generic/DashboardNumber/index.tsx
@@ -30,22 +30,23 @@ const styles = {
 };
 
 export interface DashboardNumberProps {
-  displayedNumber: number;
+  featuredNumber: number;
+  totalNumber?: number;
   showWarning?: boolean;
   onLinkClicked?: LinkProps['onFollow'];
 }
 
 const DashboardNumber: FC<DashboardNumberProps> = ({
-  showWarning, displayedNumber, onLinkClicked,
+  showWarning, featuredNumber, totalNumber, onLinkClicked,
 }) => {
   return <div css={styles.link}>
-    {showWarning && displayedNumber > 0 ? (
+    {showWarning && (totalNumber ? featuredNumber < totalNumber : featuredNumber > 0) ? (
       <SpaceBetween direction="horizontal" size="xxs">
         <Link
           variant="awsui-value-large"
           href="#"
           onFollow={onLinkClicked}>
-          {displayedNumber}
+          {totalNumber ? `${featuredNumber}/${totalNumber}` : featuredNumber}
         </Link>
         <Icon name="status-warning" variant="warning" />
       </SpaceBetween>
@@ -54,7 +55,7 @@ const DashboardNumber: FC<DashboardNumberProps> = ({
         variant="awsui-value-large"
         href="#"
         onFollow={onLinkClicked}>
-        {displayedNumber}
+        {totalNumber ? `${featuredNumber}/${totalNumber}` : featuredNumber}
       </Link>
     )}
   </div>;

--- a/packages/threat-composer/src/components/generic/GenericEntityCreationCard/index.tsx
+++ b/packages/threat-composer/src/components/generic/GenericEntityCreationCard/index.tsx
@@ -35,12 +35,6 @@ export interface GenericEntityCreationCardProps {
   validateData?: TextAreaProps['validateData'];
 }
 
-export const DEFAULT_ENTITY = {
-  id: DEFAULT_NEW_ENTITY_ID,
-  numericId: -1,
-  content: '',
-};
-
 const GenericEntityCreationCard: FC<GenericEntityCreationCardProps> = ({
   editingEntity,
   setEditingEntity,

--- a/packages/threat-composer/src/components/generic/StatusBadge/index.tsx
+++ b/packages/threat-composer/src/components/generic/StatusBadge/index.tsx
@@ -1,0 +1,72 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ ******************************************************************************************************************** */
+/** @jsxImportSource @emotion/react */
+import Badge, { BadgeProps } from '@cloudscape-design/components/badge';
+import { SelectProps } from '@cloudscape-design/components/select';
+import * as awsui from '@cloudscape-design/design-tokens';
+import { css } from '@emotion/react';
+import { FC, useMemo, useState, useRef } from 'react';
+import StatusSelector, { StatusSelectorProps } from '../StatusSelector';
+
+export interface StatusBadgeProps extends Omit<StatusSelectorProps, 'showLabel'> {
+  statusColorMapping: {
+    [status: string]: BadgeProps['color'];
+  };
+}
+
+const StatusBadge: FC<StatusBadgeProps> = ({
+  selectedOption,
+  setSelectedOption,
+  options,
+  statusColorMapping,
+}) => {
+  const ref = useRef<SelectProps.Ref>();
+
+  const [editMode, setEditMode] = useState(false);
+
+  const editor = useMemo(() => {
+    return <StatusSelector
+      ref={ref}
+      showLabel={false}
+      options={options}
+      selectedOption={selectedOption}
+      setSelectedOption={setSelectedOption}
+      onBlur={() => setEditMode(false)}
+    />;
+  }, [options, selectedOption, setSelectedOption]);
+
+  return <div>{editMode ? (editor) :
+    (<button
+      onClick={() => {
+        setEditMode(true);
+        setTimeout(() => ref.current?.focus(), 200);
+      }}
+      css={css`
+        background: none;
+        color: inherit;
+        border: none;
+        padding: 0;
+        paddingBottom: ${awsui.spaceScaledXxs};
+        font: inherit;
+        cursor: pointer;
+        outline: inherit;
+        verticalAlign: middle;
+      `}>
+      <Badge color={statusColorMapping[selectedOption || 'NotSet'] || 'grey'}>{selectedOption && options.find(x => x.value === selectedOption)?.label || 'Status Not Set'}</Badge>
+    </button>)}</div>;
+};
+
+export default StatusBadge;

--- a/packages/threat-composer/src/components/generic/StatusSelector/index.tsx
+++ b/packages/threat-composer/src/components/generic/StatusSelector/index.tsx
@@ -1,0 +1,55 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ ******************************************************************************************************************** */
+import FormField from '@cloudscape-design/components/form-field';
+import Select, { SelectProps } from '@cloudscape-design/components/select';
+import React, { FC } from 'react';
+
+export interface StatusSelectorProps {
+  options: SelectProps.Option[];
+  selectedOption?: string;
+  setSelectedOption?: (option: string) => void;
+  showLabel?: boolean;
+  onFocus?: () => void;
+  onBlur?: () => void;
+  ref?: React.ForwardedRef<any>;
+}
+
+const StatusSelector: FC<StatusSelectorProps> = React.forwardRef<SelectProps.Ref, StatusSelectorProps>(({
+  options,
+  selectedOption,
+  setSelectedOption,
+  showLabel = true,
+  onFocus,
+  onBlur,
+}, ref) => {
+  return (<FormField
+    label={showLabel ? 'Status' : undefined}
+  >
+    <Select
+      ref={ref}
+      selectedOption={(selectedOption && options?.find(x => x.value === selectedOption)) || null}
+      onChange={({ detail }) =>
+        detail.selectedOption.value && setSelectedOption?.(detail.selectedOption.value)
+      }
+      options={options}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      placeholder='Select status'
+    />
+  </FormField>);
+});
+
+export default StatusSelector;

--- a/packages/threat-composer/src/components/mitigations/MitigationCard/index.tsx
+++ b/packages/threat-composer/src/components/mitigations/MitigationCard/index.tsx
@@ -15,15 +15,19 @@
  ******************************************************************************************************************** */
 import Button from '@cloudscape-design/components/button';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
+import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import TextContent from '@cloudscape-design/components/text-content';
 import { FC, useState, useCallback } from 'react';
+import { MITIGATION_STATUS_COLOR_MAPPING } from '../../../configs/status';
 import { Mitigation, MitigationSchema } from '../../../customTypes';
+import mitigationStatus from '../../../data/status/mitigationStatus.json';
 import useEditMetadata from '../../../hooks/useEditMetadata';
 import AssumptionLink from '../../assumptions/AssumptionLink';
 import CopyToClipbord from '../../generic/CopyToClipboard';
 import MetadataEditor from '../../generic/EntityMetadataEditor';
 import GenericCard from '../../generic/GenericCard';
+import StatusBadge from '../../generic/StatusBadge';
 import Textarea from '../../generic/Textarea';
 import MitigationThreatLink from '../MitigationThreatLink';
 
@@ -70,6 +74,15 @@ const MitigationCard: FC<MitigationCardProps> = ({
     onCopy={() => onCopy?.(entity.id)}
     onRemove={() => onRemove?.(entity.id)}
     onEdit={() => setEditingMode(true)}
+    info={<StatusBadge
+      options={mitigationStatus as OptionDefinition[]}
+      selectedOption={entity.status}
+      setSelectedOption={(option) => onEdit?.({
+        ...entity,
+        status: option,
+      })}
+      statusColorMapping={MITIGATION_STATUS_COLOR_MAPPING}
+    />}
     onAddTagToEntity={(_entityId, tag) => onAddTagToEntity?.(entity, tag)}
     onRemoveTagFromEntity={(_entityId, tag) => onRemoveTagFromEntity?.(entity, tag)}
   >

--- a/packages/threat-composer/src/components/mitigations/MitigationCreationCard/index.tsx
+++ b/packages/threat-composer/src/components/mitigations/MitigationCreationCard/index.tsx
@@ -19,8 +19,9 @@ import { DEFAULT_NEW_ENTITY_ID } from '../../../configs';
 import { useAssumptionsContext } from '../../../contexts/AssumptionsContext/context';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
 import { Mitigation, MitigationSchema } from '../../../customTypes';
+import getNewMitigation from '../../../utils/getNewMitigation';
 import AssumptionLinkView from '../../assumptions/AssumptionLinkView';
-import GenericEntityCreationCard, { DEFAULT_ENTITY } from '../../generic/GenericEntityCreationCard';
+import GenericEntityCreationCard from '../../generic/GenericEntityCreationCard';
 import ThreatLinkView from '../../threats/ThreatLinkView';
 
 export interface MitigationCreationCardProps {
@@ -28,7 +29,7 @@ export interface MitigationCreationCardProps {
 }
 
 const MitigationCreationCard: FC<MitigationCreationCardProps> = ({ onSave }) => {
-  const [editingEntity, setEditingEntity] = useState<Mitigation>(DEFAULT_ENTITY);
+  const [editingEntity, setEditingEntity] = useState<Mitigation>(getNewMitigation());
   const [linkedAssumptionIds, setLinkedAssumptionIds] = useState<string[]>([]);
   const [linkedThreatIds, setLinkedThreatIds] = useState<string[]>([]);
 
@@ -37,13 +38,13 @@ const MitigationCreationCard: FC<MitigationCreationCardProps> = ({ onSave }) => 
 
   const handleSave = useCallback(() => {
     onSave?.(editingEntity, linkedAssumptionIds, linkedThreatIds);
-    setEditingEntity(DEFAULT_ENTITY);
+    setEditingEntity(getNewMitigation());
     setLinkedAssumptionIds([]);
     setLinkedThreatIds([]);
   }, [editingEntity, linkedAssumptionIds, linkedThreatIds]);
 
   const handleReset = useCallback(() => {
-    setEditingEntity(DEFAULT_ENTITY);
+    setEditingEntity(getNewMitigation());
     setLinkedAssumptionIds([]);
     setLinkedThreatIds([]);
   }, []);

--- a/packages/threat-composer/src/components/mitigations/MitigationLink/index.tsx
+++ b/packages/threat-composer/src/components/mitigations/MitigationLink/index.tsx
@@ -14,10 +14,10 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import { FC, useCallback, useEffect, useState } from 'react';
-import { DEFAULT_NEW_ENTITY_ID } from '../../../configs';
 import { useMitigationLinksContext } from '../../../contexts/MitigationLinksContext/context';
 import { useMitigationsContext } from '../../../contexts/MitigationsContext/context';
 import { MitigationLink } from '../../../customTypes';
+import getNewMitigation from '../../../utils/getNewMitigation';
 import MitigationLinkView from '../MitigationLinkView';
 
 export interface MitigationLinkProps {
@@ -49,11 +49,7 @@ const MitigationLinkComponent: FC<MitigationLinkProps> = ({
         mitigationId: mitigationIdOrNewMitigation,
       });
     } else {
-      const newMitigation = saveMitigation({
-        numericId: -1,
-        content: mitigationIdOrNewMitigation,
-        id: DEFAULT_NEW_ENTITY_ID,
-      });
+      const newMitigation = saveMitigation(getNewMitigation(mitigationIdOrNewMitigation));
       addMitigationLink({
         linkedId: linkedEntityId,
         mitigationId: newMitigation.id,

--- a/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
+++ b/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
@@ -118,21 +118,21 @@ const MitigationList: FC<MitigationListProps> = ({
       }, []);
   }, [mitigationList]);
 
-  const handleAddTagToEntity = useCallback((assumption: Mitigation, tag: string) => {
+  const handleAddTagToEntity = useCallback((mitigation: Mitigation, tag: string) => {
     const updated: Mitigation = {
-      ...assumption,
-      tags: assumption.tags ?
-        (!assumption.tags.includes(tag) ?
-          [...assumption.tags, tag] : assumption.tags) :
+      ...mitigation,
+      tags: mitigation.tags ?
+        (!mitigation.tags.includes(tag) ?
+          [...mitigation.tags, tag] : mitigation.tags) :
         [tag],
     };
     saveMitigation(updated);
   }, [saveMitigation]);
 
-  const handleRemoveTagFromEntity = useCallback((assumption: Mitigation, tag: string) => {
+  const handleRemoveTagFromEntity = useCallback((mitigation: Mitigation, tag: string) => {
     const updated: Mitigation = {
-      ...assumption,
-      tags: assumption.tags?.filter(t => t !== tag),
+      ...mitigation,
+      tags: mitigation.tags?.filter(t => t !== tag),
     };
     saveMitigation(updated);
   }, [saveMitigation]);

--- a/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
+++ b/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
@@ -20,10 +20,10 @@ import Multiselect from '@cloudscape-design/components/multiselect';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import { FC, useCallback, useMemo, useState } from 'react';
-import { LEVEL_NOT_SET } from '../../../configs';
+import { STATUS_NOT_SET } from '../../../configs';
 import { useAssumptionLinksContext, useMitigationLinksContext } from '../../../contexts';
 import { useMitigationsContext } from '../../../contexts/MitigationsContext/context';
-import { AssumptionLink, Mitigation, MitigationLink } from '../../../customTypes';
+import { AssumptionLink, Mitigation, MitigationLink, MitigationListFilter } from '../../../customTypes';
 import mitigationStatus from '../../../data/status/mitigationStatus.json';
 import ContentLayout from '../../generic/ContentLayout';
 import LinkedEntityFilter, { ALL, WITHOUT_NO_LINKED_ENTITY, WITH_LINKED_ENTITY } from '../../generic/LinkedEntityFilter';
@@ -36,10 +36,16 @@ const ALL_STATUS = [...mitigationStatus.map(ia => ({
   value: ia.value,
 })), {
   label: 'Not Set',
-  value: LEVEL_NOT_SET,
+  value: STATUS_NOT_SET,
 }];
 
-const MitigationList: FC = () => {
+export interface MitigationListProps {
+  initialFilter?: MitigationListFilter;
+}
+
+const MitigationList: FC<MitigationListProps> = ({
+  initialFilter,
+}) => {
   const {
     mitigationList,
     removeMitigation,
@@ -68,7 +74,7 @@ const MitigationList: FC = () => {
   const [
     selectedStatus,
     setSelectedStatus,
-  ] = useState<string[]>([]);
+  ] = useState<string[]>(initialFilter?.status || []);
 
   const [
     selectedLinkedThreatsFilter,
@@ -146,7 +152,7 @@ const MitigationList: FC = () => {
 
     if (selectedStatus && selectedStatus.length > 0) {
       output = output.filter(st => {
-        return st.status ? selectedStatus.includes(st.status) : selectedStatus.includes(LEVEL_NOT_SET);
+        return st.status ? selectedStatus.includes(st.status) : selectedStatus.includes(STATUS_NOT_SET);
       });
     }
 

--- a/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
+++ b/packages/threat-composer/src/components/mitigations/MitigationList/index.tsx
@@ -16,17 +16,28 @@
 import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
 import Grid from '@cloudscape-design/components/grid';
+import Multiselect from '@cloudscape-design/components/multiselect';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import { FC, useCallback, useMemo, useState } from 'react';
+import { LEVEL_NOT_SET } from '../../../configs';
 import { useAssumptionLinksContext, useMitigationLinksContext } from '../../../contexts';
 import { useMitigationsContext } from '../../../contexts/MitigationsContext/context';
 import { AssumptionLink, Mitigation, MitigationLink } from '../../../customTypes';
+import mitigationStatus from '../../../data/status/mitigationStatus.json';
 import ContentLayout from '../../generic/ContentLayout';
 import LinkedEntityFilter, { ALL, WITHOUT_NO_LINKED_ENTITY, WITH_LINKED_ENTITY } from '../../generic/LinkedEntityFilter';
 import TagSelector from '../../generic/TagSelector';
 import MitigationCard from '../MitigationCard';
 import MitigationCreationCard from '../MitigationCreationCard';
+
+const ALL_STATUS = [...mitigationStatus.map(ia => ({
+  label: ia.label,
+  value: ia.value,
+})), {
+  label: 'Not Set',
+  value: LEVEL_NOT_SET,
+}];
 
 const MitigationList: FC = () => {
   const {
@@ -55,6 +66,11 @@ const MitigationList: FC = () => {
   ] = useState<string[]>([]);
 
   const [
+    selectedStatus,
+    setSelectedStatus,
+  ] = useState<string[]>([]);
+
+  const [
     selectedLinkedThreatsFilter,
     setSelectedLinkedThreatsFilter,
   ] = useState(ALL);
@@ -63,6 +79,7 @@ const MitigationList: FC = () => {
     selectedLinkedAssumptionsFilter,
     setSelectedLinkedAssumptionsFilter,
   ] = useState(ALL);
+
 
   const handleRemove = useCallback(async (mitigationId: string) => {
     removeMitigation(mitigationId);
@@ -74,13 +91,16 @@ const MitigationList: FC = () => {
     return (filteringText === ''
       && selectedLinkedAssumptionsFilter === ALL
       && selectedLinkedThreatsFilter === ALL
-      && selectedTags.length === 0);
-  }, [filteringText, selectedTags,
+      && selectedTags.length === 0
+      && selectedStatus.length === 0
+    );
+  }, [filteringText, selectedTags, selectedStatus,
     selectedLinkedThreatsFilter, selectedLinkedAssumptionsFilter]);
 
   const handleClearFilter = useCallback(() => {
     setFilteringText('');
     setSelectedTags([]);
+    setSelectedStatus([]);
     setSelectedLinkedAssumptionsFilter(ALL);
     setSelectedLinkedThreatsFilter(ALL);
   }, []);
@@ -124,9 +144,15 @@ const MitigationList: FC = () => {
       });
     }
 
+    if (selectedStatus && selectedStatus.length > 0) {
+      output = output.filter(st => {
+        return st.status ? selectedStatus.includes(st.status) : selectedStatus.includes(LEVEL_NOT_SET);
+      });
+    }
+
     if (selectedLinkedThreatsFilter !== ALL) {
       output = output.filter(st => {
-        return mitigationLinkList.some(ml => ml. mitigationId === st.id) ?
+        return mitigationLinkList.some(ml => ml.mitigationId === st.id) ?
           selectedLinkedThreatsFilter === WITH_LINKED_ENTITY :
           selectedLinkedThreatsFilter === WITHOUT_NO_LINKED_ENTITY;
       });
@@ -143,7 +169,7 @@ const MitigationList: FC = () => {
     output = output.sort((op1, op2) => (op2.displayOrder || Number.MAX_VALUE) - (op1.displayOrder || Number.MAX_VALUE));
 
     return output;
-  }, [filteringText, mitigationList, selectedTags,
+  }, [filteringText, mitigationList, selectedTags, selectedStatus,
     assumptionLinkList, mitigationLinkList,
     selectedLinkedAssumptionsFilter, selectedLinkedThreatsFilter]);
 
@@ -189,16 +215,28 @@ const MitigationList: FC = () => {
           />
           <Grid
             gridDefinition={[
-              { colspan: { default: 12, xs: 3 } },
+              { colspan: { default: 12, xs: 5 } },
+              { colspan: { default: 12, xs: 5 } },
               { colspan: { default: 12, xs: 4 } },
               { colspan: { default: 12, xs: 4 } },
-              { colspan: { default: 1 } },
+              { colspan: { default: 3 } },
             ]}
           >
             <TagSelector
               allTags={allTags}
               selectedTags={selectedTags}
               setSelectedTags={setSelectedTags}
+            />
+            <Multiselect
+              tokenLimit={0}
+              selectedOptions={ALL_STATUS.filter(x => selectedStatus.includes(x.value))}
+              onChange={({ detail }) =>
+                setSelectedStatus(detail.selectedOptions?.map(o => o.value || '') || [])
+              }
+              deselectAriaLabel={e => `Remove ${e.label}`}
+              options={ALL_STATUS}
+              placeholder="Filtered by status"
+              selectedAriaLabel="Selected"
             />
             <LinkedEntityFilter
               label='Linked threats'
@@ -213,18 +251,10 @@ const MitigationList: FC = () => {
               setSelected={setSelectedLinkedAssumptionsFilter}
             />
             <Button onClick={handleClearFilter}
-              variant='icon'
-              iconSvg={<svg
-                focusable="false"
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                tabIndex={-1}
-              >
-                <path d="M19.79 5.61C20.3 4.95 19.83 4 19 4H6.83l7.97 7.97 4.99-6.36zM2.81 2.81 1.39 4.22 10 13v6c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.17l5.78 5.78 1.41-1.41L2.81 2.81z"></path>
-              </svg>}
-              ariaLabel='Clear filters'
               disabled={hasNoFilter}
-            />
+            >
+              Clear filters
+            </Button>
           </Grid>
         </SpaceBetween>
       </Container>

--- a/packages/threat-composer/src/components/report/ThreatModel/components/ThreatModelView/index.tsx
+++ b/packages/threat-composer/src/components/report/ThreatModel/components/ThreatModelView/index.tsx
@@ -174,7 +174,7 @@ const ThreatModelView: FC<ThreatModelViewProps> = ({
       buttons.push(<Button key='addThreats' onClick={() => props.onThreatListView?.()}>Add Threats</Button>);
     }
     if (!hasContentDetails?.mitigations) {
-      buttons.push(<Button key='addMitigations' onClick={props.onMitigationListView}>Add Mitigations</Button>);
+      buttons.push(<Button key='addMitigations' onClick={() => props.onMitigationListView?.()}>Add Mitigations</Button>);
     }
     const len = buttons.length;
     return buttons.flatMap((b, index) => index === len - 1 ? <Box>{b}</Box> : [b, <Box fontWeight="bold" css={styles.text}>or</Box>]);

--- a/packages/threat-composer/src/components/threats/MetadataEditor/index.tsx
+++ b/packages/threat-composer/src/components/threats/MetadataEditor/index.tsx
@@ -16,22 +16,28 @@
 /** @jsxImportSource @emotion/react */
 import ExpandableSection, { ExpandableSectionProps } from '@cloudscape-design/components/expandable-section';
 import Grid from '@cloudscape-design/components/grid';
+import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
 import { FC, useMemo } from 'react';
 import { TemplateThreatStatement } from '../../../customTypes';
+import threatStatus from '../../../data/status/threatStatus.json';
 import expandablePanelHeaderStyles from '../../../styles/expandablePanelHeader';
 import CommentsEdit from '../../generic/CommentsEdit';
+import StatusSelector from '../../generic/StatusSelector';
 import STRIDESELECTOR from '../../generic/STRIDESelector';
 import PriorityEdit from '../PriorityEdit';
+
 
 export interface MetadataEditorProps {
   variant: ExpandableSectionProps['variant'];
   editingStatement: TemplateThreatStatement;
+  onEditStatementStatus: (statement: TemplateThreatStatement, status: string) => void;
   onEditMetadata: (statement: TemplateThreatStatement, key: string, value: string | string[] | undefined) => void;
 }
 
 const MetadataEditor: FC<MetadataEditorProps> = ({
   variant,
   editingStatement,
+  onEditStatementStatus,
   onEditMetadata,
 }) => {
   const stride = useMemo(() => {
@@ -43,10 +49,16 @@ const MetadataEditor: FC<MetadataEditorProps> = ({
       <Grid
         gridDefinition={[
           { colspan: { default: 12, xs: 3 } },
-          { colspan: { default: 12, xs: 9 } },
+          { colspan: { default: 12, xs: 3 } },
+          { colspan: { default: 12, xs: 6 } },
           { colspan: { default: 12, xs: 12 } },
         ]}
       >
+        <StatusSelector
+          selectedOption={editingStatement.status}
+          setSelectedOption={(option) => onEditStatementStatus(editingStatement, option)}
+          options={threatStatus as OptionDefinition[]}
+        />
         <PriorityEdit
           editingStatement={editingStatement}
           onEditMetadata={onEditMetadata}

--- a/packages/threat-composer/src/components/threats/ThreatStatementCard/index.tsx
+++ b/packages/threat-composer/src/components/threats/ThreatStatementCard/index.tsx
@@ -17,13 +17,17 @@
 import { SpaceBetween } from '@cloudscape-design/components';
 import ButtonDropdown, { ButtonDropdownProps } from '@cloudscape-design/components/button-dropdown';
 import ColumnLayout from '@cloudscape-design/components/column-layout';
+import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
 import { CancelableEventHandler } from '@cloudscape-design/components/internal/events';
 import TextContent from '@cloudscape-design/components/text-content';
 import { FC, useCallback, useMemo } from 'react';
+import { THREAT_STATUS_COLOR_MAPPING } from '../../../configs/status';
 import { TemplateThreatStatement } from '../../../customTypes';
+import threatStatus from '../../../data/status/threatStatus.json';
 import AssumptionLink from '../../assumptions/AssumptionLink';
 import CopyToClipbord from '../../generic/CopyToClipboard';
 import GenericCard from '../../generic/GenericCard';
+import StatusBadge from '../../generic/StatusBadge';
 import MitigationLink from '../../mitigations/MitigationLink';
 import MetadataEditor from '../MetadataEditor';
 import PriorityBadge from '../PriorityBadge';
@@ -34,6 +38,7 @@ export interface ThreatStatementCardProps {
   onCopy?: (id: string) => void;
   onRemove?: (id: string) => void;
   onEditInWizard?: (id: string) => void;
+  onEditStatementStatus: (statement: TemplateThreatStatement, status: string) => void;
   onEditMetadata: (statement: TemplateThreatStatement, key: string, value: string | string[] | undefined) => void;
   onAddTagToStatement?: (statement: TemplateThreatStatement, tag: string) => void;
   onRemoveTagFromStatement?: (statement: TemplateThreatStatement, tag: string) => void;
@@ -47,6 +52,7 @@ const ThreatStatementCard: FC<ThreatStatementCardProps> = ({
   onEditInWizard,
   onAddTagToStatement,
   onRemoveTagFromStatement,
+  onEditStatementStatus,
   onEditMetadata,
 }) => {
   const handleMoreActions: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails> = useCallback(({ detail }) => {
@@ -85,7 +91,15 @@ const ThreatStatementCard: FC<ThreatStatementCardProps> = ({
   return (<GenericCard
     header={`Threat ${statement.numericId}`}
     entityId={statement.id}
-    info={<PriorityBadge editingStatement={statement} onEditMetadata={onEditMetadata} />}
+    info={<SpaceBetween direction='horizontal' size='s'>
+      <StatusBadge
+        options={threatStatus as OptionDefinition[]}
+        setSelectedOption={(option) => onEditStatementStatus(statement, option)}
+        selectedOption={statement.status}
+        statusColorMapping={THREAT_STATUS_COLOR_MAPPING}
+      />
+      <PriorityBadge editingStatement={statement} onEditMetadata={onEditMetadata} />
+    </SpaceBetween>}
     tags={statement.tags}
     moreActions={moreActions}
     onRemove={onRemove}
@@ -113,6 +127,7 @@ const ThreatStatementCard: FC<ThreatStatementCardProps> = ({
       <MetadataEditor
         variant='default'
         editingStatement={statement}
+        onEditStatementStatus={onEditStatementStatus}
         onEditMetadata={onEditMetadata}
       />
     </SpaceBetween>

--- a/packages/threat-composer/src/components/threats/ThreatStatementEditor/index.tsx
+++ b/packages/threat-composer/src/components/threats/ThreatStatementEditor/index.tsx
@@ -37,6 +37,7 @@ import threatFieldData from '../../../data/threatFieldData';
 import threatStatementExamples from '../../../data/threatStatementExamples.json';
 import threatStatementFormat from '../../../data/threatStatementFormat';
 import useEditMetadata from '../../../hooks/useEditMetadata';
+import getNewMitigation from '../../../utils/getNewMitigation';
 import getNewThreatStatement from '../../../utils/getNewThreatStatement';
 import getRecommendedEditor from '../../../utils/getRecommandedEditor';
 import renderThreatStatement from '../../../utils/renderThreatStatement';
@@ -329,11 +330,7 @@ export const ThreatStatementEditorInner: FC<ThreatStatementEditorProps & { editi
     if (mitigationList.find(a => a.id === mitigationIdOrNewMitigation)) {
       setLinkedMitigationIds(prev => [...prev, mitigationIdOrNewMitigation]);
     } else {
-      const newMitigation = saveMitigation({
-        id: DEFAULT_NEW_ENTITY_ID,
-        numericId: -1,
-        content: mitigationIdOrNewMitigation,
-      });
+      const newMitigation = saveMitigation(getNewMitigation(mitigationIdOrNewMitigation));
       setLinkedMitigationIds(prev => [...prev, newMitigation.id]);
     }
 

--- a/packages/threat-composer/src/components/threats/ThreatStatementEditor/index.tsx
+++ b/packages/threat-composer/src/components/threats/ThreatStatementEditor/index.tsx
@@ -21,7 +21,6 @@ import TextContent from '@cloudscape-design/components/text-content';
 import * as awsui from '@cloudscape-design/design-tokens';
 import { css } from '@emotion/react';
 import React, { FC, useCallback, useMemo, useState, useRef, useEffect, ReactNode, PropsWithChildren } from 'react';
-import { v4 as uuidV4 } from 'uuid';
 import { EditorProps } from './types';
 import { DEFAULT_NEW_ENTITY_ID, DEFAULT_WORKSPACE_LABEL } from '../../../configs/constants';
 import { useAssumptionLinksContext } from '../../../contexts/AssumptionLinksContext/context';
@@ -256,11 +255,9 @@ export const ThreatStatementEditorInner: FC<ThreatStatementEditorProps & { editi
   const handleExampleClicked = useCallback((statement: TemplateThreatStatement) => {
     setEditingStatement({
       ...statement,
+      ...getNewThreatStatement(),
       tags: [],
       metadata: [],
-      displayOrder: -1,
-      numericId: -1,
-      id: uuidV4(),
     });
     const recommendedEditor = getRecommendedEditor(statement);
     recommendedEditor && setEditor(recommendedEditor);
@@ -273,11 +270,9 @@ export const ThreatStatementEditorInner: FC<ThreatStatementEditorProps & { editi
     const example = threatStatementExamples[randomNumber] as TemplateThreatStatement;
     const statement = {
       ...example,
+      ...getNewThreatStatement(),
       tags: [],
       metadata: [],
-      displayOrder: -1,
-      numericId: -1,
-      id: uuidV4(),
     };
 
     setEditingStatement(statement);

--- a/packages/threat-composer/src/components/threats/ThreatStatementEditor/index.tsx
+++ b/packages/threat-composer/src/components/threats/ThreatStatementEditor/index.tsx
@@ -409,6 +409,10 @@ export const ThreatStatementEditorInner: FC<ThreatStatementEditorProps & { editi
             <MetadataEditor
               variant='container'
               editingStatement={editingStatement}
+              onEditStatementStatus={(_statement, status) => setEditingStatement((prev => ({
+                ...prev,
+                status,
+              } as TemplateThreatStatement)))}
               onEditMetadata={handleEditMetadata}
             />
           </div>}

--- a/packages/threat-composer/src/components/threats/ThreatStatementList/index.tsx
+++ b/packages/threat-composer/src/components/threats/ThreatStatementList/index.tsx
@@ -23,7 +23,7 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import TextFilter from '@cloudscape-design/components/text-filter';
 import { css } from '@emotion/react';
 import { FC, PropsWithChildren, useCallback, useMemo, useState } from 'react';
-import { LEVEL_SELECTOR_OPTIONS, DEFAULT_NEW_ENTITY_ID, LEVEL_NOT_SET } from '../../../configs';
+import { LEVEL_SELECTOR_OPTIONS, DEFAULT_NEW_ENTITY_ID, LEVEL_NOT_SET, STATUS_NOT_SET } from '../../../configs';
 import { useAssumptionLinksContext, useMitigationLinksContext } from '../../../contexts';
 import { GlobalSetupContextApi, useGlobalSetupContext } from '../../../contexts/GlobalSetupContext/context';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
@@ -69,7 +69,7 @@ const ALL_STATUS = [...threatStatus.map(ia => ({
   value: ia.value,
 })), {
   label: 'Not Set',
-  value: LEVEL_NOT_SET,
+  value: STATUS_NOT_SET,
 }];
 
 const ContentLayout: FC<PropsWithChildren<ContentLayoutProps & {
@@ -149,7 +149,7 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
   const [
     selectedStatus,
     setSelectedStatus,
-  ] = useState<string[]>([]);
+  ] = useState<string[]>(initialFilter?.status || []);
 
   const [
     selectedPriorities,
@@ -225,7 +225,7 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
 
     if (selectedStatus && selectedStatus.length > 0) {
       output = output.filter(st => {
-        return st.status ? selectedStatus.includes(st.status) : selectedStatus.includes(LEVEL_NOT_SET);
+        return st.status ? selectedStatus.includes(st.status) : selectedStatus.includes(STATUS_NOT_SET);
       });
     }
 

--- a/packages/threat-composer/src/components/threats/ThreatStatementList/index.tsx
+++ b/packages/threat-composer/src/components/threats/ThreatStatementList/index.tsx
@@ -28,6 +28,7 @@ import { useAssumptionLinksContext, useMitigationLinksContext } from '../../../c
 import { GlobalSetupContextApi, useGlobalSetupContext } from '../../../contexts/GlobalSetupContext/context';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
 import { TemplateThreatStatement, ThreatStatementListFilter, ViewNavigationEvent } from '../../../customTypes';
+import threatStatus from '../../../data/status/threatStatus.json';
 import useEditMetadata from '../../../hooks/useEditMetadata';
 import { addTagToEntity, removeTagFromEntity } from '../../../utils/entityTag';
 import AssetSelector from '../../generic/AssetSelector';
@@ -59,9 +60,17 @@ const styles = {
   btnClearFilter: css({
     height: '100%',
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
   }),
 };
+
+const ALL_STATUS = [...threatStatus.map(ia => ({
+  label: ia.label,
+  value: ia.value,
+})), {
+  label: 'Not Set',
+  value: LEVEL_NOT_SET,
+}];
 
 const ContentLayout: FC<PropsWithChildren<ContentLayoutProps & {
   composerMode: GlobalSetupContextApi['composerMode'];
@@ -138,6 +147,11 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
   ] = useState<string[]>([]);
 
   const [
+    selectedStatus,
+    setSelectedStatus,
+  ] = useState<string[]>([]);
+
+  const [
     selectedPriorities,
     setSelectedPriorities,
   ] = useState<string[]>(initialFilter && initialFilter.priority ? [initialFilter.priority] : []);
@@ -175,6 +189,13 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
     saveStatement(updated);
   }, []);
 
+  const handleUpdateStatementStatus = useCallback((statement: TemplateThreatStatement, status: string) => {
+    saveStatement({
+      ...statement,
+      status,
+    });
+  }, [saveStatement]);
+
   const filteredStatementList = useMemo(() => {
     let output = statementList;
 
@@ -199,6 +220,12 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
     if (selectedTags && selectedTags.length > 0) {
       output = output.filter(st => {
         return st.tags?.some(t => selectedTags.includes(t));
+      });
+    }
+
+    if (selectedStatus && selectedStatus.length > 0) {
+      output = output.filter(st => {
+        return st.status ? selectedStatus.includes(st.status) : selectedStatus.includes(LEVEL_NOT_SET);
       });
     }
 
@@ -262,7 +289,7 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
   }, [filteringText, statementList,
     assumptionLinkList, mitigationLinkList,
     selectedImpactedAssets, selectedImpactedGoal,
-    selectedTags, selectedPriorities, selectedSTRIDEs,
+    selectedTags, selectedStatus, selectedPriorities, selectedSTRIDEs,
     selectedLinkedAssumptionFilter, selectedLinkedMitigationFilter,
     sortBy]);
 
@@ -271,12 +298,13 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
       && selectedImpactedAssets.length === 0
       && selectedImpactedGoal.length === 0
       && selectedTags.length === 0
+      && selectedStatus.length === 0
       && selectedPriorities.length === 0
       && selectedSTRIDEs.length === 0
       && selectedLinkedAssumptionFilter === ALL
       && selectedLinkedMitigationFilter === ALL);
   }, [filteringText, selectedImpactedAssets, selectedImpactedGoal,
-    selectedTags, selectedPriorities, selectedSTRIDEs,
+    selectedTags, selectedStatus, selectedPriorities, selectedSTRIDEs,
     selectedLinkedAssumptionFilter, selectedLinkedMitigationFilter]);
 
   const handleAddStatement = useCallback((idToCopy?: string) => {
@@ -345,6 +373,7 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
     setSelectedImpactedAssets([]);
     setSelectedImpactedGoal([]);
     setSelectedTags([]);
+    setSelectedStatus([]);
     setSelectedPriorities([]);
     setSelectedSTRIDEs([]);
     setSelectedLinkedAssumptionFilter(ALL);
@@ -352,19 +381,24 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
   }, []);
 
   const gridDefinition = useMemo(() => {
-    return composerMode === 'Full' ? [{ colspan: { default: 12, xs: 6, s: 2 } },
-      { colspan: { default: 12, xs: 6, s: 2 } },
+    return composerMode === 'Full' ? [{ colspan: { default: 12, xs: 6, s: 3 } },
       { colspan: { default: 12, xs: 6, s: 3 } },
       { colspan: { default: 12, xs: 6, s: 3 } },
-      { colspan: { default: 12, xs: 6, s: 2 } },
+      { colspan: { default: 12, xs: 6, s: 3 } },
       { colspan: { default: 12, xs: 6, s: 5 } },
       { colspan: { default: 12, xs: 6, s: 5 } },
-      { colspan: { default: 12, xs: 6, s: 2 } }] : [{ colspan: { default: 12, xs: 6, s: 2 } },
-      { colspan: { default: 12, xs: 6, s: 2 } },
-      { colspan: { default: 12, xs: 6, s: 2.5 } },
-      { colspan: { default: 12, xs: 6, s: 2.5 } },
-      { colspan: { default: 12, xs: 5, s: 2 } },
-      { colspan: { default: 1 } }];
+      { colspan: { default: 12, xs: 6, s: 4 } },
+      { colspan: { default: 12, xs: 6, s: 4 } },
+      { colspan: { default: 12, xs: 6, s: 4 } }] :
+      [
+        { colspan: { default: 12, xs: 6, s: 3 } },
+        { colspan: { default: 12, xs: 6, s: 3 } },
+        { colspan: { default: 12, xs: 6, s: 3 } },
+        { colspan: { default: 12, xs: 6, s: 3 } },
+        { colspan: { default: 12, xs: 6, s: 5 } },
+        { colspan: { default: 12, xs: 6, s: 5 } },
+        { colspan: { default: 2 } },
+      ];
   }, [composerMode]);
 
   return (<ContentLayout
@@ -419,6 +453,22 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
               placeholder="Filtered by STRIDE"
               selectedAriaLabel="Selected"
             />
+            <TagSelector
+              allTags={allTags}
+              selectedTags={selectedTags}
+              setSelectedTags={setSelectedTags}
+            />
+            <Multiselect
+              tokenLimit={0}
+              selectedOptions={ALL_STATUS.filter(x => selectedStatus.includes(x.value))}
+              onChange={({ detail }) =>
+                setSelectedStatus(detail.selectedOptions?.map(o => o.value || '') || [])
+              }
+              deselectAriaLabel={e => `Remove ${e.label}`}
+              options={ALL_STATUS}
+              placeholder="Filtered by status"
+              selectedAriaLabel="Selected"
+            />
             <AssetSelector
               allAssets={allImpactedAssets}
               selectedAssets={selectedImpactedAssets}
@@ -441,11 +491,6 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
               placeholder="Filtered by impacted goal"
               selectedAriaLabel="Selected"
             />
-            <TagSelector
-              allTags={allTags}
-              selectedTags={selectedTags}
-              setSelectedTags={setSelectedTags}
-            />
             {composerMode === 'Full' && <LinkedEntityFilter
               label='Linked mitigations'
               entityDisplayName='mitigations'
@@ -458,25 +503,13 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
               selected={selectedLinkedAssumptionFilter}
               setSelected={setSelectedLinkedAssumptionFilter}
             />}
-            {composerMode === 'Full' ? (<div css={styles.btnClearFilter}>
+            {<div css={styles.btnClearFilter}>
               <div><Button onClick={handleClearFilter}
                 disabled={hasNoFilter}
               >
                 Clear filters
               </Button></div>
-            </div>) : <Button onClick={handleClearFilter}
-              variant='icon'
-              iconSvg={<svg
-                focusable="false"
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                tabIndex={-1}
-              >
-                <path d="M19.79 5.61C20.3 4.95 19.83 4 19 4H6.83l7.97 7.97 4.99-6.36zM2.81 2.81 1.39 4.22 10 13v6c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-2.17l5.78 5.78 1.41-1.41L2.81 2.81z"></path>
-              </svg>}
-              ariaLabel='Clear filters'
-              disabled={hasNoFilter}
-            />}
+            </div>}
           </Grid>
           <Grid
             gridDefinition={[{ colspan: { default: 12, xs: 6 } }]}
@@ -493,6 +526,7 @@ const ThreatStatementList: FC<ThreatStatementListProps> = ({
           onRemove={handleRemove}
           onEditInWizard={handleEditStatement}
           onEditMetadata={handleEditMetadata}
+          onEditStatementStatus={handleUpdateStatementStatus}
           onAddTagToStatement={handleAddTagToStatement}
           onRemoveTagFromStatement={handleRemoveTagFromStatement}
           showLinkedEntities={composerMode === 'Full'}

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/MitigationStatus/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/MitigationStatus/index.tsx
@@ -1,0 +1,167 @@
+/** *******************************************************************************************************************
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ ******************************************************************************************************************** */
+import {
+  Button,
+  Box,
+  ColumnLayout,
+} from '@cloudscape-design/components';
+import PieChart from '@cloudscape-design/components/pie-chart';
+import {
+  colorChartsStatusInfo,
+  colorChartsStatusPositive,
+  colorChartsStatusHigh,
+  colorChartsStatusNeutral,
+  colorChartsStatusLow,
+} from '@cloudscape-design/design-tokens';
+import { useMemo, useCallback, FC } from 'react';
+import {
+  MITIGATION_STATUS_IDENTIFIED,
+  MITIGATION_STATUS_IN_PROGRESS,
+  MITIGATION_STATUS_RESOLVED,
+  MITIGATION_STATUS_RESOLVED_ABANDONED,
+  STATUS_NOT_SET,
+} from '../../../../../configs';
+import { useMitigationsContext } from '../../../../../contexts/MitigationsContext';
+import { mitigationStatus } from '../../../../../data';
+import DashboardNumber from '../../../../generic/DashboardNumber';
+import useMitigationListLinkClicked from '../../hooks/useMitigationListLinkClicked';
+import { WorkspaceInsightsProps } from '../../types';
+
+const MitigationStatus: FC<WorkspaceInsightsProps> = ({
+  onMitigationListView,
+}) => {
+  const { mitigationList } = useMitigationsContext();
+
+  const handleLinkClicked = useMitigationListLinkClicked(onMitigationListView);
+
+  const countNotSet = useMemo(() => mitigationList.filter(x => !x.status).length,
+    [mitigationList],
+  );
+
+  const countIdentified = useMemo(
+    () => mitigationList.filter(x => x.status === MITIGATION_STATUS_IDENTIFIED).length,
+    [mitigationList],
+  );
+
+  const countResolved = useMemo(
+    () => mitigationList.filter(x => x.status === MITIGATION_STATUS_RESOLVED).length,
+    [mitigationList],
+  );
+
+  const countInProgress = useMemo(
+    () => mitigationList.filter(x => x.status === MITIGATION_STATUS_IN_PROGRESS).length,
+    [mitigationList],
+  );
+
+  const countAbandoned = useMemo(
+    () => mitigationList.filter(x => x.status === MITIGATION_STATUS_RESOLVED_ABANDONED).length,
+    [mitigationList],
+  );
+
+  const handleAddMitigation = useCallback(() => {
+    onMitigationListView?.();
+  }, [mitigationList, onMitigationListView]);
+
+  return (
+    <ColumnLayout columns={1} borders="horizontal">
+      {!mitigationList.length ? (
+        <Box
+          margin="xxl"
+          padding="xxl"
+          color="text-body-secondary"
+          textAlign="center"
+        >
+          <b>No mitigations available</b>
+          <Box variant="p" color="text-body-secondary">
+            Start by adding a mitigation to this workspace
+          </Box>
+          <Button variant="primary" onClick={() => handleAddMitigation()}>Add a mitigation</Button>
+        </Box>
+      ) : (
+        <Box padding="s">
+          <PieChart
+            data={[
+              {
+                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_RESOLVED)?.label || 'Resolved',
+                value: countResolved,
+                color: colorChartsStatusPositive,
+              },
+              {
+                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_RESOLVED_ABANDONED)?.label || 'Abandoned',
+                value: countAbandoned,
+                color: colorChartsStatusLow,
+              },
+              {
+                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_IN_PROGRESS)?.label || 'In progress',
+                value: countInProgress,
+                color: colorChartsStatusInfo,
+              },
+              {
+                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_IDENTIFIED)?.label || 'Identified',
+                value: countIdentified,
+                color: colorChartsStatusNeutral,
+              },
+              {
+                title: 'Not Set',
+                value: countNotSet,
+                color: colorChartsStatusHigh,
+              },
+            ]}
+            detailPopoverContent={(datum, sum) => [
+              { key: 'Mitigation count', value: datum.value },
+              {
+                key: 'Percentage',
+                value: `${((datum.value / sum) * 100).toFixed(0)}%`,
+              },
+            ]}
+            segmentDescription={(datum, sum) =>
+              `${datum.value} mitigations, ${((datum.value / sum) * 100).toFixed(0)}%`
+            }
+            ariaDescription="Pie chart showing the status of mitigations."
+            ariaLabel="Pie chart"
+            hideFilter
+            innerMetricDescription="Mitigations"
+            innerMetricValue={mitigationList.length.toString()}
+            variant="donut"
+            size="medium"
+            noMatch={
+              <Box textAlign="center" color="inherit">
+                <b>No matching data</b>
+                <Box variant="p" color="inherit">
+                  There is no matching data to display
+                </Box>
+                <Button>Clear filter</Button>
+              </Box>
+            }
+          />
+        </Box>
+      )}
+      {countNotSet > 0 ? (
+        <div>
+          <Box variant="awsui-key-label">Missing status</Box>
+          <DashboardNumber
+            showWarning
+            featuredNumber={countNotSet}
+            onLinkClicked={handleLinkClicked({
+              status: [STATUS_NOT_SET],
+            })}
+          />
+        </div>
+      ) : null}
+    </ColumnLayout>
+  );
+};
+export default MitigationStatus;

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/MitigationStatus/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/MitigationStatus/index.tsx
@@ -31,7 +31,7 @@ import {
   MITIGATION_STATUS_IDENTIFIED,
   MITIGATION_STATUS_IN_PROGRESS,
   MITIGATION_STATUS_RESOLVED,
-  MITIGATION_STATUS_RESOLVED_ABANDONED,
+  MITIGATION_STATUS_RESOLVED_WILLNOTACTION,
   STATUS_NOT_SET,
 } from '../../../../../configs';
 import { useMitigationsContext } from '../../../../../contexts/MitigationsContext';
@@ -66,8 +66,8 @@ const MitigationStatus: FC<WorkspaceInsightsProps> = ({
     [mitigationList],
   );
 
-  const countAbandoned = useMemo(
-    () => mitigationList.filter(x => x.status === MITIGATION_STATUS_RESOLVED_ABANDONED).length,
+  const countWillNotAction = useMemo(
+    () => mitigationList.filter(x => x.status === MITIGATION_STATUS_RESOLVED_WILLNOTACTION).length,
     [mitigationList],
   );
 
@@ -100,8 +100,8 @@ const MitigationStatus: FC<WorkspaceInsightsProps> = ({
                 color: colorChartsStatusPositive,
               },
               {
-                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_RESOLVED_ABANDONED)?.label || 'Abandoned',
-                value: countAbandoned,
+                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_RESOLVED_WILLNOTACTION)?.label || 'Will not action',
+                value: countWillNotAction,
                 color: colorChartsStatusLow,
               },
               {

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/MitigationStatus/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/MitigationStatus/index.tsx
@@ -105,7 +105,7 @@ const MitigationStatus: FC<WorkspaceInsightsProps> = ({
                 color: colorChartsStatusLow,
               },
               {
-                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_IN_PROGRESS)?.label || 'In progress',
+                title: mitigationStatus.find(x => x.value === MITIGATION_STATUS_IN_PROGRESS)?.label || 'In-progress',
                 value: countInProgress,
                 color: colorChartsStatusInfo,
               },

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/Overview/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/Overview/index.tsx
@@ -20,7 +20,7 @@ import ColumnLayout from '@cloudscape-design/components/column-layout';
 import { LinkProps } from '@cloudscape-design/components/link';
 import { css } from '@emotion/react';
 import { useMemo, FC, ReactNode } from 'react';
-import { LEVEL_HIGH, LEVEL_LOW, LEVEL_MEDIUM, LEVEL_NOT_SET, MITIGATION_STATUS_IDENTIFIED, MITIGATION_STATUS_IN_PROGRESS, MITIGATION_STATUS_RESOLVED, MITIGATION_STATUS_RESOLVED_ABANDONED, STATUS_NOT_SET, THREAT_STATUS_IDENTIFIED, THREAT_STATUS_NOT_USEFUL, THREAT_STATUS_RESOLVED } from '../../../../../configs';
+import { LEVEL_HIGH, LEVEL_LOW, LEVEL_MEDIUM, LEVEL_NOT_SET, MITIGATION_STATUS_IDENTIFIED, MITIGATION_STATUS_IN_PROGRESS, MITIGATION_STATUS_RESOLVED, MITIGATION_STATUS_RESOLVED_WILLNOTACTION, STATUS_NOT_SET, THREAT_STATUS_IDENTIFIED, THREAT_STATUS_NOT_USEFUL, THREAT_STATUS_RESOLVED } from '../../../../../configs';
 import { useAssumptionLinksContext, useMitigationsContext } from '../../../../../contexts';
 import { useMitigationLinksContext } from '../../../../../contexts/MitigationLinksContext';
 import { useThreatsContext } from '../../../../../contexts/ThreatsContext';
@@ -97,7 +97,7 @@ const Overview: FC<WorkspaceInsightsProps> = ({
   const [completedMitigations, totalMitigations] = useMemo(() => {
     return [
       mitigationList.filter((m) => m.status === MITIGATION_STATUS_RESOLVED
-        || m.status === MITIGATION_STATUS_RESOLVED_ABANDONED).length,
+        || m.status === MITIGATION_STATUS_RESOLVED_WILLNOTACTION).length,
       mitigationList.length,
     ];
   }, [mitigationList]);

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/Overview/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/Overview/index.tsx
@@ -20,13 +20,14 @@ import ColumnLayout from '@cloudscape-design/components/column-layout';
 import { LinkProps } from '@cloudscape-design/components/link';
 import { css } from '@emotion/react';
 import { useMemo, FC, ReactNode } from 'react';
-import { LEVEL_HIGH, LEVEL_LOW, LEVEL_MEDIUM, LEVEL_NOT_SET } from '../../../../../configs';
-import { useAssumptionLinksContext } from '../../../../../contexts';
+import { LEVEL_HIGH, LEVEL_LOW, LEVEL_MEDIUM, LEVEL_NOT_SET, MITIGATION_STATUS_IDENTIFIED, MITIGATION_STATUS_IN_PROGRESS, MITIGATION_STATUS_RESOLVED, MITIGATION_STATUS_RESOLVED_ABANDONED, STATUS_NOT_SET, THREAT_STATUS_IDENTIFIED, THREAT_STATUS_NOT_USEFUL, THREAT_STATUS_RESOLVED } from '../../../../../configs';
+import { useAssumptionLinksContext, useMitigationsContext } from '../../../../../contexts';
 import { useMitigationLinksContext } from '../../../../../contexts/MitigationLinksContext';
 import { useThreatsContext } from '../../../../../contexts/ThreatsContext';
 import filterThreatsByMetadata from '../../../../../utils/filterThreatsByMetadata';
 import DashboardNumber from '../../../../generic/DashboardNumber';
-import useLinkClicked from '../../hooks/useLinkClicked';
+import useMitigationListLinkClicked from '../../hooks/useMitigationListLinkClicked';
+import useThreatListLinkClicked from '../../hooks/useThreatListLinkClicked';
 import { WorkspaceInsightsProps } from '../../types';
 
 const styles = {
@@ -45,15 +46,17 @@ const styles = {
 const LabelValuePair: FC<{
   label: string | ReactNode;
   value: number;
+  totalValue?: number;
   onLinkFollow: LinkProps['onFollow'];
   showWarning?: boolean;
-}> = ({ label, value, onLinkFollow, showWarning }) => {
+}> = ({ label, value, totalValue, onLinkFollow, showWarning }) => {
   return (<div css={styles.container} >
     <Box variant="awsui-key-label">{label}</Box>
     <div css={styles.contentContainer}>
       <DashboardNumber
         showWarning={showWarning}
-        displayedNumber={value}
+        featuredNumber={value}
+        totalNumber={totalValue}
         onLinkClicked={onLinkFollow}
       />
     </div>
@@ -62,8 +65,10 @@ const LabelValuePair: FC<{
 
 const Overview: FC<WorkspaceInsightsProps> = ({
   onThreatListView,
+  onMitigationListView,
 }) => {
   const { statementList } = useThreatsContext();
+  const { mitigationList } = useMitigationsContext();
   const { mitigationLinkList } = useMitigationLinksContext();
   const { assumptionLinkList } = useAssumptionLinksContext();
 
@@ -75,7 +80,9 @@ const Overview: FC<WorkspaceInsightsProps> = ({
     ).length;
   }, [statementList, mitigationLinkList, assumptionLinkList]);
 
-  const handleLinkClicked = useLinkClicked(onThreatListView);
+  const handleThreatListLinkClicked = useThreatListLinkClicked(onThreatListView);
+
+  const handleMitigationListLinkClicked = useMitigationListLinkClicked(onMitigationListView);
 
   const missingMitigation = useMemo(() => {
     return statementList.filter(
@@ -86,6 +93,22 @@ const Overview: FC<WorkspaceInsightsProps> = ({
   const missingPriority = useMemo(() => {
     return filterThreatsByMetadata(statementList, 'Priority').length;
   }, [statementList]);
+
+  const [completedMitigations, totalMitigations] = useMemo(() => {
+    return [
+      mitigationList.filter((m) => m.status === MITIGATION_STATUS_RESOLVED
+        || m.status === MITIGATION_STATUS_RESOLVED_ABANDONED).length,
+      mitigationList.length,
+    ];
+  }, [mitigationList]);
+
+  const [completedThreats, totalThreats] = useMemo(() => {
+    return [
+      statementList.filter((st) => st.status === THREAT_STATUS_NOT_USEFUL
+        || st.status === THREAT_STATUS_RESOLVED).length,
+      statementList.length,
+    ];
+  }, [mitigationList]);
 
   const countHigh = useMemo(() => {
     return filterThreatsByMetadata(statementList, 'Priority', LEVEL_HIGH)
@@ -101,41 +124,55 @@ const Overview: FC<WorkspaceInsightsProps> = ({
   }, [statementList]);
 
   return (
-    <ColumnLayout columns={7} variant="text-grid" minColumnWidth={100}>
-      <LabelValuePair label='Total' value={statementList.length} onLinkFollow={handleLinkClicked()} />
+    <ColumnLayout columns={7} variant="text-grid" minColumnWidth={120}>
+      <LabelValuePair label='Total' value={statementList.length} onLinkFollow={handleThreatListLinkClicked()} />
       <LabelValuePair label='No mitigation and assumption'
         showWarning
         value={missingMitigationOrAssumption}
-        onLinkFollow={handleLinkClicked({
+        onLinkFollow={handleThreatListLinkClicked({
           linkedMitigations: false,
           linkedAssumptions: false,
         })} />
       <LabelValuePair label='No mitigation'
         showWarning
         value={missingMitigation}
-        onLinkFollow={handleLinkClicked({
+        onLinkFollow={handleThreatListLinkClicked({
           linkedMitigations: false,
         })} />
       <LabelValuePair label={<Badge color="red">High</Badge>}
         value={countHigh}
-        onLinkFollow={handleLinkClicked({
+        onLinkFollow={handleThreatListLinkClicked({
           priority: LEVEL_HIGH,
         })} />
       <LabelValuePair label={<Badge color="blue">Med</Badge>}
         value={countMed}
-        onLinkFollow={handleLinkClicked({
+        onLinkFollow={handleThreatListLinkClicked({
           priority: LEVEL_MEDIUM,
         })} />
       <LabelValuePair label={<Badge color="green">Low</Badge>}
         value={countLow}
-        onLinkFollow={handleLinkClicked({
+        onLinkFollow={handleThreatListLinkClicked({
           priority: LEVEL_LOW,
         })} />
       <LabelValuePair label='Missing priority'
         showWarning
         value={missingPriority}
-        onLinkFollow={handleLinkClicked({
+        onLinkFollow={handleThreatListLinkClicked({
           priority: LEVEL_NOT_SET,
+        })} />
+      <LabelValuePair label='Threat progress'
+        showWarning
+        value={completedThreats}
+        totalValue={totalThreats}
+        onLinkFollow={handleThreatListLinkClicked({
+          status: [STATUS_NOT_SET, THREAT_STATUS_IDENTIFIED],
+        })} />
+      <LabelValuePair label='Mitigation progress'
+        showWarning
+        value={completedMitigations}
+        totalValue={totalMitigations}
+        onLinkFollow={handleMitigationListLinkClicked({
+          status: [STATUS_NOT_SET, MITIGATION_STATUS_IN_PROGRESS, MITIGATION_STATUS_IDENTIFIED],
         })} />
     </ColumnLayout>
   );

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/STRIDEAllocation/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/STRIDEAllocation/index.tsx
@@ -32,7 +32,7 @@ import {
 import { useThreatsContext } from '../../../../../contexts/ThreatsContext';
 import filterThreatsByMetadata from '../../../../../utils/filterThreatsByMetadata';
 import DashboardNumber from '../../../../generic/DashboardNumber';
-import useLinkClicked from '../../hooks/useLinkClicked';
+import useThreatListLinkClicked from '../../hooks/useThreatListLinkClicked';
 import { WorkspaceInsightsProps } from '../../types';
 
 const STRIDEAllocation: FC<WorkspaceInsightsProps> = ({
@@ -83,7 +83,7 @@ const STRIDEAllocation: FC<WorkspaceInsightsProps> = ({
     [filteredStatementList],
   );
 
-  const handleLinkClicked = useLinkClicked(onThreatListView);
+  const handleLinkClicked = useThreatListLinkClicked(onThreatListView);
 
   const barSeries: BarChartProps<string>['series'] = [
     {
@@ -187,7 +187,7 @@ const STRIDEAllocation: FC<WorkspaceInsightsProps> = ({
           <Box variant="awsui-key-label">Missing STRIDE</Box>
           <DashboardNumber
             showWarning
-            displayedNumber={missingStride}
+            featuredNumber={missingStride}
             onLinkClicked={handleLinkClicked({
               stride: LEVEL_NOT_SET,
             })}

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/ThreatGrammar/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/ThreatGrammar/index.tsx
@@ -202,7 +202,7 @@ const ThreatGrammar: FC<WorkspaceInsightsProps> = ({
           <Box variant="awsui-key-label">Not using grammar</Box>
           <DashboardNumber
             showWarning
-            displayedNumber={notUsingGrammar}
+            featuredNumber={notUsingGrammar}
           />
         </div>
       ) : null}

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/ThreatStatus/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/components/ThreatStatus/index.tsx
@@ -27,19 +27,19 @@ import {
 } from '@cloudscape-design/design-tokens';
 import { useMemo, useCallback, FC } from 'react';
 import {
-  LEVEL_HIGH,
-  LEVEL_LOW,
-  LEVEL_MEDIUM,
-  LEVEL_NOT_SET,
   DEFAULT_NEW_ENTITY_ID,
+  STATUS_NOT_SET,
+  THREAT_STATUS_IDENTIFIED,
+  THREAT_STATUS_NOT_USEFUL,
+  THREAT_STATUS_RESOLVED,
 } from '../../../../../configs';
 import { useThreatsContext } from '../../../../../contexts/ThreatsContext';
-import filterThreatsByMetadata from '../../../../../utils/filterThreatsByMetadata';
+import { threatStatus } from '../../../../../data';
 import DashboardNumber from '../../../../generic/DashboardNumber';
 import useThreatListLinkClicked from '../../hooks/useThreatListLinkClicked';
 import { WorkspaceInsightsProps } from '../../types';
 
-const ThreatPrioritization: FC<WorkspaceInsightsProps> = ({
+const ThreatStatus: FC<WorkspaceInsightsProps> = ({
   onThreatEditorView,
   onThreatListView,
 }) => {
@@ -47,22 +47,22 @@ const ThreatPrioritization: FC<WorkspaceInsightsProps> = ({
 
   const handleLinkClicked = useThreatListLinkClicked(onThreatListView);
 
-  const missingPriority = useMemo(
-    () => filterThreatsByMetadata(statementList, 'Priority').length,
+  const countNotSet = useMemo(() => statementList.filter(x => !x.status).length,
     [statementList],
   );
 
-  const countHigh = useMemo(
-    () => filterThreatsByMetadata(statementList, 'Priority', LEVEL_HIGH).length,
+  const countIdentified = useMemo(
+    () => statementList.filter(x => x.status === THREAT_STATUS_IDENTIFIED).length,
     [statementList],
   );
-  const countMed = useMemo(
-    () =>
-      filterThreatsByMetadata(statementList, 'Priority', LEVEL_MEDIUM).length,
+
+  const countResolved = useMemo(
+    () => statementList.filter(x => x.status === THREAT_STATUS_RESOLVED).length,
     [statementList],
   );
-  const countLow = useMemo(
-    () => filterThreatsByMetadata(statementList, 'Priority', LEVEL_LOW).length,
+
+  const countNotUseful = useMemo(
+    () => statementList.filter(x => x.status === THREAT_STATUS_NOT_USEFUL).length,
     [statementList],
   );
 
@@ -91,24 +91,24 @@ const ThreatPrioritization: FC<WorkspaceInsightsProps> = ({
           <PieChart
             data={[
               {
-                title: 'High',
-                value: countHigh,
-                color: colorChartsStatusHigh,
-              },
-              {
-                title: 'Medium',
-                value: countMed,
-                color: colorChartsStatusInfo,
-              },
-              {
-                title: 'Low',
-                value: countLow,
+                title: threatStatus.find(x => x.value === THREAT_STATUS_RESOLVED)?.label || 'Resolved',
+                value: countResolved,
                 color: colorChartsStatusPositive,
               },
               {
-                title: 'Undefined',
-                value: missingPriority,
+                title: threatStatus.find(x => x.value === THREAT_STATUS_NOT_USEFUL)?.label || 'Not useful',
+                value: countNotUseful,
+                color: colorChartsStatusInfo,
+              },
+              {
+                title: threatStatus.find(x => x.value === THREAT_STATUS_IDENTIFIED)?.label || 'Identified',
+                value: countIdentified,
                 color: colorChartsStatusNeutral,
+              },
+              {
+                title: 'Not Set',
+                value: countNotSet,
+                color: colorChartsStatusHigh,
               },
             ]}
             detailPopoverContent={(datum, sum) => [
@@ -121,7 +121,7 @@ const ThreatPrioritization: FC<WorkspaceInsightsProps> = ({
             segmentDescription={(datum, sum) =>
               `${datum.value} threats, ${((datum.value / sum) * 100).toFixed(0)}%`
             }
-            ariaDescription="Pie chart showing the prioritization of threats."
+            ariaDescription="Pie chart showing the status of threats."
             ariaLabel="Pie chart"
             hideFilter
             innerMetricDescription="Threats"
@@ -140,14 +140,14 @@ const ThreatPrioritization: FC<WorkspaceInsightsProps> = ({
           />
         </Box>
       )}
-      {missingPriority > 0 ? (
+      {countNotSet > 0 ? (
         <div>
-          <Box variant="awsui-key-label">Missing priority</Box>
+          <Box variant="awsui-key-label">Missing status</Box>
           <DashboardNumber
             showWarning
-            featuredNumber={missingPriority}
+            featuredNumber={countNotSet}
             onLinkClicked={handleLinkClicked({
-              priority: LEVEL_NOT_SET,
+              status: [STATUS_NOT_SET],
             })}
           />
         </div>
@@ -155,4 +155,4 @@ const ThreatPrioritization: FC<WorkspaceInsightsProps> = ({
     </ColumnLayout>
   );
 };
-export default ThreatPrioritization;
+export default ThreatStatus;

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/hooks/useMitigationListLinkClicked/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/hooks/useMitigationListLinkClicked/index.tsx
@@ -13,15 +13,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import { MitigationListFilter } from './mitigations';
-import { ThreatStatementListFilter } from './threats';
+import { CancelableEventHandler, BaseNavigationDetail } from '@cloudscape-design/components/internal/events';
+import { useCallback } from 'react';
+import { MitigationListFilter, ViewNavigationEvent } from '../../../../../customTypes';
 
-export interface ViewNavigationEvent {
-  onApplicationInfoView?: () => void;
-  onArchitectureView?: () => void;
-  onDataflowView?: () => void;
-  onAssumptionListView?: () => void;
-  onMitigationListView?: (filter?: MitigationListFilter) => void;
-  onThreatListView?: (filter?: ThreatStatementListFilter) => void;
-  onThreatEditorView?: (threatId: string, idToCopy?: string) => void;
-}
+const useMitigationListLinkClicked = (onMitigationListView: ViewNavigationEvent['onMitigationListView']) => {
+  return useCallback((filter?: MitigationListFilter): CancelableEventHandler<BaseNavigationDetail> => (event) => {
+    event?.preventDefault?.();
+    onMitigationListView?.(filter);
+  }, [onMitigationListView]);
+};
+
+export default useMitigationListLinkClicked;
+

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/hooks/useThreatListLinkClicked/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/hooks/useThreatListLinkClicked/index.tsx
@@ -17,12 +17,12 @@ import { CancelableEventHandler, BaseNavigationDetail } from '@cloudscape-design
 import { useCallback } from 'react';
 import { ThreatStatementListFilter, ViewNavigationEvent } from '../../../../../customTypes';
 
-const useLinkClicked = (onThreatListView: ViewNavigationEvent['onThreatListView']) => {
+const useThreatListLinkClicked = (onThreatListView: ViewNavigationEvent['onThreatListView']) => {
   return useCallback((filter?: ThreatStatementListFilter): CancelableEventHandler<BaseNavigationDetail> => (event) => {
     event?.preventDefault?.();
     onThreatListView?.(filter);
   }, [onThreatListView]);
 };
 
-export default useLinkClicked;
+export default useThreatListLinkClicked;
 

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/index.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/index.tsx
@@ -17,10 +17,12 @@ import Board, { BoardProps } from '@cloudscape-design/board-components/board';
 import BoardItem from '@cloudscape-design/board-components/board-item';
 import Header from '@cloudscape-design/components/header';
 import { useState, ReactNode, useCallback, FC } from 'react';
+import MitigationStatus from './components/MitigationStatus';
 import Overview from './components/Overview';
 import STRIDEAllocation from './components/STRIDEAllocation';
 import ThreatGrammar from './components/ThreatGrammar';
 import ThreatPrioritization from './components/ThreatPrioritization';
+import ThreatStatus from './components/ThreatStatus';
 import { WorkspaceInsightsProps } from './types';
 import ContentLayout from '../../generic/ContentLayout';
 
@@ -35,7 +37,7 @@ const WorkspaceInsights: FC<WorkspaceInsightsProps> = (props) => {
   const [items, setItems] = useState<BoardProps.Item<ItemType>[]>([
     {
       id: 'overview',
-      rowSpan: 2,
+      rowSpan: 3,
       columnSpan: 6,
       data: { title: 'Threat summary', content: <Overview {...props}/> },
     },
@@ -44,6 +46,12 @@ const WorkspaceInsights: FC<WorkspaceInsightsProps> = (props) => {
       rowSpan: 5,
       columnSpan: 2,
       data: { title: 'Threat prioritization', content: <ThreatPrioritization {...props}/> },
+    },
+    {
+      id: 'threat-status',
+      rowSpan: 5,
+      columnSpan: 2,
+      data: { title: 'Threat status', content: <ThreatStatus {...props}/> },
     },
     {
       id: 'stride-allocation',
@@ -56,6 +64,12 @@ const WorkspaceInsights: FC<WorkspaceInsightsProps> = (props) => {
       rowSpan: 5,
       columnSpan: 2,
       data: { title: 'Threat grammar distribution', content: <ThreatGrammar {...props}/> },
+    },
+    {
+      id: 'mitigation-status',
+      rowSpan: 5,
+      columnSpan: 2,
+      data: { title: 'Mitigation status', content: <MitigationStatus {...props}/> },
     },
   ]);
 

--- a/packages/threat-composer/src/components/workspaces/WorkspaceInsights/types.tsx
+++ b/packages/threat-composer/src/components/workspaces/WorkspaceInsights/types.tsx
@@ -19,4 +19,5 @@ import { ViewNavigationEvent } from '../../../customTypes';
 export interface WorkspaceInsightsProps {
   onThreatEditorView?: ViewNavigationEvent['onThreatEditorView'];
   onThreatListView?: ViewNavigationEvent['onThreatListView'];
+  onMitigationListView?: ViewNavigationEvent['onMitigationListView'];
 }

--- a/packages/threat-composer/src/configs/index.ts
+++ b/packages/threat-composer/src/configs/index.ts
@@ -21,3 +21,4 @@ export * from './styles';
 export * from './options';
 export * from './metadata';
 export * from './appMode';
+export * from './status';

--- a/packages/threat-composer/src/configs/status.ts
+++ b/packages/threat-composer/src/configs/status.ts
@@ -21,7 +21,7 @@ export const DEFAULT_THREAT_STATUS = THREAT_STATUS_IDENTIFIED;
 export const MITIGATION_STATUS_IDENTIFIED = 'mitigationIdentified';
 export const MITIGATION_STATUS_IN_PROGRESS = 'mitigationInProgress';
 export const MITIGATION_STATUS_RESOLVED = 'mitigationResolved';
-export const MITIGATION_STATUS_RESOLVED_ABANDONED = 'mitigationResolvedAbandoned';
+export const MITIGATION_STATUS_RESOLVED_WILLNOTACTION = 'mitigationResolvedWillNotAction';
 export const DEFAULT_MITIGATION_STATUS = MITIGATION_STATUS_IDENTIFIED;
 
 export const STATUS_NOT_SET = 'NoSet';
@@ -30,7 +30,7 @@ export const MITIGATION_STATUS_COLOR_MAPPING: any = {
   mitigationIdentified: 'grey',
   mitigationInProgress: 'blue',
   mitigationResolved: 'green',
-  mitigationResolvedAbandoned: 'red',
+  mitigationResolvedWillNotAction: 'red',
   NotSet: 'grey',
 };
 

--- a/packages/threat-composer/src/configs/status.ts
+++ b/packages/threat-composer/src/configs/status.ts
@@ -13,15 +13,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import { v4 as uuidV4 } from 'uuid';
-import { TemplateThreatStatement } from '../../customTypes';
-
-const getNewThreatStatement = (): TemplateThreatStatement => {
-  return {
-    id: uuidV4(),
-    numericId: -1,
-    status: 'threatIdentified',
-  };
+export const MITIGATION_STATUS_COLOR_MAPPING: any = {
+  mitigationIdentified: 'grey',
+  mitigationInProgress: 'blue',
+  mitigationResolved: 'green',
+  mitigationResolvedAbandoned: 'red',
+  NotSet: 'grey',
 };
 
-export default getNewThreatStatement;
+export const THREAT_STATUS_COLOR_MAPPING: any = {
+  threatIdentified: 'grey',
+  threatResolvedNotUseful: 'blue',
+  threatResolved: 'green',
+  NotSet: 'grey',
+};
+

--- a/packages/threat-composer/src/configs/status.ts
+++ b/packages/threat-composer/src/configs/status.ts
@@ -13,8 +13,17 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-export const DEFAULT_MITIGATION_STATUS = 'mitigationIdentified';
-export const DEFAULT_THREAT_STATUS = 'threatIdentified';
+export const THREAT_STATUS_IDENTIFIED = 'threatIdentified';
+export const THREAT_STATUS_RESOLVED = 'threatResolved';
+export const THREAT_STATUS_NOT_USEFUL = 'threatResolvedNotUseful';
+export const DEFAULT_THREAT_STATUS = THREAT_STATUS_IDENTIFIED;
+
+export const MITIGATION_STATUS_IDENTIFIED = 'mitigationIdentified';
+export const MITIGATION_STATUS_IN_PROGRESS = 'mitigationInProgress';
+export const MITIGATION_STATUS_RESOLVED = 'mitigationResolved';
+export const MITIGATION_STATUS_RESOLVED_ABANDONED = 'mitigationResolvedAbandoned';
+export const DEFAULT_MITIGATION_STATUS = MITIGATION_STATUS_IDENTIFIED;
+
 export const STATUS_NOT_SET = 'NoSet';
 
 export const MITIGATION_STATUS_COLOR_MAPPING: any = {

--- a/packages/threat-composer/src/contexts/MitigationPacksContext/index.tsx
+++ b/packages/threat-composer/src/contexts/MitigationPacksContext/index.tsx
@@ -14,13 +14,13 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import { FC, PropsWithChildren, useCallback, useMemo } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { MitigationPacksContext, useMitigationPacksContext } from './context';
 import { MitigationPacksContextProviderProps } from './types';
 import { METADATA_KEY_SOURCE, METADATA_KEY_SOURCE_MITIGATION_PACK, METADATA_KEY_SOURCE_MITIGATION_PACK_MITIGATION, METADATA_SOURCE_MITIGATION_PACK } from '../../configs';
 import { MitigationPack, MitigationPackUsage, Mitigation } from '../../customTypes';
 import mitigationPacks from '../../data/mitigationPacks/mitigationPacks';
 import getMetadata from '../../utils/getMetadata';
+import getNewMitigation from '../../utils/getNewMitigation';
 import { useMitigationsContext } from '../MitigationsContext';
 
 const MitigationPacksContextProvider: FC<PropsWithChildren<MitigationPacksContextProviderProps>> = ({
@@ -66,9 +66,8 @@ const MitigationPacksContextProvider: FC<PropsWithChildren<MitigationPacksContex
     mitigations.forEach(m => {
       if (!usage[m.id]) {
         saveMitigation({
+          ...getNewMitigation(m.content),
           ...m,
-          numericId: -1,
-          id: uuidv4(),
           metadata: [
             ...(m.metadata || []),
             {

--- a/packages/threat-composer/src/customTypes/entities.ts
+++ b/packages/threat-composer/src/customTypes/entities.ts
@@ -85,6 +85,8 @@ export const EntityBaseSchema = z.object({
 
 export type EntityBase = z.infer<typeof EntityBaseSchema>;
 
+export const StatusSchema = z.string().optional();
+
 export const ContentEntityBaseSchema = EntityBaseSchema.extend({
   /**
    * The text content of the Assumption.

--- a/packages/threat-composer/src/customTypes/mitigations.ts
+++ b/packages/threat-composer/src/customTypes/mitigations.ts
@@ -14,9 +14,14 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import { z } from 'zod';
-import { ContentEntityBaseSchema, EntityLinkBaseSchema } from './entities';
+import { ContentEntityBaseSchema, EntityLinkBaseSchema, StatusSchema } from './entities';
+import mitigationStatus from '../data/status/mitigationStatus.json';
 
-export const MitigationSchema = ContentEntityBaseSchema.extend({}).strict();;
+export const MitigationSchema = ContentEntityBaseSchema.extend({
+  status: StatusSchema.refine((schema) => {
+    return !schema || mitigationStatus.map(x => x.value).includes(schema);
+  }, 'Invalid mitigation status'),
+}).strict();;
 
 export type Mitigation = z.infer<typeof MitigationSchema>;
 

--- a/packages/threat-composer/src/customTypes/mitigations.ts
+++ b/packages/threat-composer/src/customTypes/mitigations.ts
@@ -15,6 +15,7 @@
  ******************************************************************************************************************** */
 import { z } from 'zod';
 import { ContentEntityBaseSchema, EntityLinkBaseSchema, StatusSchema } from './entities';
+import { MITIGATION_STATUS_IDENTIFIED, MITIGATION_STATUS_IN_PROGRESS, MITIGATION_STATUS_RESOLVED, MITIGATION_STATUS_RESOLVED_ABANDONED, STATUS_NOT_SET } from '../configs';
 import mitigationStatus from '../data/status/mitigationStatus.json';
 
 export const MitigationSchema = ContentEntityBaseSchema.extend({
@@ -37,3 +38,11 @@ export const MitigationLinkSchema = EntityLinkBaseSchema.extend({
 }).strict();;
 
 export type MitigationLink = z.infer<typeof MitigationLinkSchema>;
+
+export interface MitigationListFilter {
+  status?: (typeof MITIGATION_STATUS_IDENTIFIED
+    | typeof MITIGATION_STATUS_IN_PROGRESS
+    | typeof MITIGATION_STATUS_RESOLVED
+    | typeof MITIGATION_STATUS_RESOLVED_ABANDONED
+    | typeof STATUS_NOT_SET)[];
+}

--- a/packages/threat-composer/src/customTypes/mitigations.ts
+++ b/packages/threat-composer/src/customTypes/mitigations.ts
@@ -15,7 +15,7 @@
  ******************************************************************************************************************** */
 import { z } from 'zod';
 import { ContentEntityBaseSchema, EntityLinkBaseSchema, StatusSchema } from './entities';
-import { MITIGATION_STATUS_IDENTIFIED, MITIGATION_STATUS_IN_PROGRESS, MITIGATION_STATUS_RESOLVED, MITIGATION_STATUS_RESOLVED_ABANDONED, STATUS_NOT_SET } from '../configs';
+import { MITIGATION_STATUS_IDENTIFIED, MITIGATION_STATUS_IN_PROGRESS, MITIGATION_STATUS_RESOLVED, MITIGATION_STATUS_RESOLVED_WILLNOTACTION, STATUS_NOT_SET } from '../configs';
 import mitigationStatus from '../data/status/mitigationStatus.json';
 
 export const MitigationSchema = ContentEntityBaseSchema.extend({
@@ -43,6 +43,6 @@ export interface MitigationListFilter {
   status?: (typeof MITIGATION_STATUS_IDENTIFIED
     | typeof MITIGATION_STATUS_IN_PROGRESS
     | typeof MITIGATION_STATUS_RESOLVED
-    | typeof MITIGATION_STATUS_RESOLVED_ABANDONED
+    | typeof MITIGATION_STATUS_RESOLVED_WILLNOTACTION
     | typeof STATUS_NOT_SET)[];
 }

--- a/packages/threat-composer/src/customTypes/threats.ts
+++ b/packages/threat-composer/src/customTypes/threats.ts
@@ -14,8 +14,9 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import { z } from 'zod';
-import { EntityBaseSchema } from './entities';
+import { EntityBaseSchema, StatusSchema } from './entities';
 import { SINGLE_FIELD_INPUT_MAX_LENGTH, LEVEL_HIGH, LEVEL_MEDIUM, LEVEL_LOW, LEVEL_NOT_SET } from '../configs';
+import threatStatus from '../data/status/threatStatus.json';
 
 export const ThreatStatementDisplayTokenSchema = z.object({
   /**
@@ -75,6 +76,12 @@ export const TemplateThreatStatementSchema = EntityBaseSchema.extend({
     * A list of displayed statement token
     */
   displayedStatement: z.union([ThreatStatementDisplayTokenSchema, z.string()]).array().optional(),
+  /**
+   * The status of the threats.
+   */
+  status: StatusSchema.refine((schema ) => {
+    return !schema || threatStatus.map(x => x.value).includes(schema);
+  }, 'Invalid threat status'),
 }).strict();
 
 export type TemplateThreatStatement = z.infer<typeof TemplateThreatStatementSchema>;

--- a/packages/threat-composer/src/customTypes/threats.ts
+++ b/packages/threat-composer/src/customTypes/threats.ts
@@ -15,7 +15,7 @@
  ******************************************************************************************************************** */
 import { z } from 'zod';
 import { EntityBaseSchema, StatusSchema } from './entities';
-import { SINGLE_FIELD_INPUT_MAX_LENGTH, LEVEL_HIGH, LEVEL_MEDIUM, LEVEL_LOW, LEVEL_NOT_SET } from '../configs';
+import { SINGLE_FIELD_INPUT_MAX_LENGTH, LEVEL_HIGH, LEVEL_MEDIUM, LEVEL_LOW, LEVEL_NOT_SET, STATUS_NOT_SET, THREAT_STATUS_IDENTIFIED, THREAT_STATUS_NOT_USEFUL, THREAT_STATUS_RESOLVED } from '../configs';
 import threatStatus from '../data/status/threatStatus.json';
 
 export const ThreatStatementDisplayTokenSchema = z.object({
@@ -79,7 +79,7 @@ export const TemplateThreatStatementSchema = EntityBaseSchema.extend({
   /**
    * The status of the threats.
    */
-  status: StatusSchema.refine((schema ) => {
+  status: StatusSchema.refine((schema) => {
     return !schema || threatStatus.map(x => x.value).includes(schema);
   }, 'Invalid threat status'),
 }).strict();
@@ -102,6 +102,7 @@ export interface ThreatStatementListFilter {
   linkedAssumptions?: boolean;
   priority?: typeof LEVEL_HIGH | typeof LEVEL_MEDIUM | typeof LEVEL_LOW | typeof LEVEL_NOT_SET;
   stride?: 'S' | 'T' | 'R' | 'I' | 'D' | 'E' | typeof LEVEL_NOT_SET;
+  status?: (typeof THREAT_STATUS_IDENTIFIED | typeof THREAT_STATUS_NOT_USEFUL | typeof THREAT_STATUS_RESOLVED | typeof STATUS_NOT_SET)[];
 }
 
 export interface ThreatStatementFormat {

--- a/packages/threat-composer/src/data/index.ts
+++ b/packages/threat-composer/src/data/index.ts
@@ -13,22 +13,5 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-export const DEFAULT_MITIGATION_STATUS = 'mitigationIdentified';
-export const DEFAULT_THREAT_STATUS = 'threatIdentified';
-export const STATUS_NOT_SET = 'NoSet';
-
-export const MITIGATION_STATUS_COLOR_MAPPING: any = {
-  mitigationIdentified: 'grey',
-  mitigationInProgress: 'blue',
-  mitigationResolved: 'green',
-  mitigationResolvedAbandoned: 'red',
-  NotSet: 'grey',
-};
-
-export const THREAT_STATUS_COLOR_MAPPING: any = {
-  threatIdentified: 'grey',
-  threatResolvedNotUseful: 'blue',
-  threatResolved: 'green',
-  NotSet: 'grey',
-};
-
+export { default as threatStatus } from './status/threatStatus.json';
+export { default as mitigationStatus } from './status/mitigationStatus.json';

--- a/packages/threat-composer/src/data/status/mitigationStatus.json
+++ b/packages/threat-composer/src/data/status/mitigationStatus.json
@@ -1,0 +1,26 @@
+[
+    {
+        "label": "Identified",
+        "value": "mitigationIdentified",
+        "description": "Mitigation has been identified",
+        "iconName": "suggestions"
+    },
+    {
+        "label": "In-Progress",
+        "value": "mitigationInProgress",
+        "description": "Mitigation is in-progress",
+        "iconName": "status-in-progress"
+    },
+    {
+        "label": "Resolved",
+        "value": "mitigationResolved",
+        "description": "Mitigation has been completed to an agreed scoped",
+        "iconName": "status-positive"
+    },
+    {
+        "label": "Abandoned",
+        "value": "mitigationResolvedAbandoned",
+        "description": "Will not be implementing this mitigation",
+        "iconName": "flag"
+    }
+]

--- a/packages/threat-composer/src/data/status/mitigationStatus.json
+++ b/packages/threat-composer/src/data/status/mitigationStatus.json
@@ -18,8 +18,8 @@
         "iconName": "status-positive"
     },
     {
-        "label": "Abandoned",
-        "value": "mitigationResolvedAbandoned",
+        "label": "Will not action",
+        "value": "mitigationResolvedWillNotAction",
         "description": "Will not be implementing this mitigation",
         "iconName": "flag"
     }

--- a/packages/threat-composer/src/data/status/mitigationStatus.json
+++ b/packages/threat-composer/src/data/status/mitigationStatus.json
@@ -6,7 +6,7 @@
         "iconName": "suggestions"
     },
     {
-        "label": "In-Progress",
+        "label": "In-progress",
         "value": "mitigationInProgress",
         "description": "Mitigation is in-progress",
         "iconName": "status-in-progress"

--- a/packages/threat-composer/src/data/status/threatStatus.json
+++ b/packages/threat-composer/src/data/status/threatStatus.json
@@ -1,0 +1,20 @@
+[
+    {
+        "label": "Identified",
+        "value": "threatIdentified",
+        "description": "Potential threat has been identified",
+        "iconName": "suggestions"
+    },
+    {
+        "label": "Resolved",
+        "value": "threatResolved",
+        "description": "All agreed risk response actions (mitigation, transfer, avoidance, risk acceptance) have been completed aligned to our risk tolerance",
+        "iconName": "status-positive"
+    },
+    {
+        "label": "Not Useful",
+        "value": "threatResolvedNotUseful",
+        "description": "This threat is invalid / not applicable to our use system",
+        "iconName": "delete-marker"
+    }
+]

--- a/packages/threat-composer/src/index.ts
+++ b/packages/threat-composer/src/index.ts
@@ -20,3 +20,4 @@ export * from './customTypes';
 export * from './hooks';
 export * from './configs';
 export * from './utils';
+export * from './data';

--- a/packages/threat-composer/src/utils/convertToMarkdown/utils/getMitigations/index.ts
+++ b/packages/threat-composer/src/utils/convertToMarkdown/utils/getMitigations/index.ts
@@ -13,7 +13,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
+import { STATUS_NOT_SET } from '../../../../configs';
 import { DataExchangeFormat } from '../../../../customTypes';
+import mitigationStatus from '../../../../data/status/mitigationStatus.json';
 import escapeMarkdown from '../../../../utils/escapeMarkdown';
 import parseTableCellContent from '../../../../utils/parseTableCellContent';
 import standardizeNumericId from '../../../../utils/standardizeNumericId';
@@ -26,8 +28,8 @@ export const getMitigationsContent = async (
 
   rows.push('\n');
 
-  rows.push('| Mitigation Number | Mitigation | Threats Mitigating | Assumptions | Comments |');
-  rows.push('| --- | --- | --- | --- | --- |');
+  rows.push('| Mitigation Number | Mitigation | Threats Mitigating | Assumptions | Status | Comments |');
+  rows.push('| --- | --- | --- | --- | --- | --- |');
 
   if (data.mitigations) {
     const promises = data.mitigations.map(async (x) => {
@@ -52,10 +54,12 @@ export const getMitigationsContent = async (
         return null;
       }).filter(a => !!a).join('<br/>');
 
+      const status = (x.status && mitigationStatus.find(ms => ms.value === x.status)?.label) || STATUS_NOT_SET;
+
       const comments = await parseTableCellContent((x.metadata?.find(m => m.key === 'Comments')?.value as string) || '');
 
       const mitigationId = `M-${standardizeNumericId(x.numericId)}`;
-      return `| <a name="${mitigationId}"></a>${mitigationId} | ${escapeMarkdown(x.content)} | ${threatsContent} | ${assumptionsContent} | ${comments} |`;
+      return `| <a name="${mitigationId}"></a>${mitigationId} | ${escapeMarkdown(x.content)} | ${threatsContent} | ${assumptionsContent} | ${status} | ${comments} |`;
     });
 
     rows.push(...(await Promise.all(promises)));

--- a/packages/threat-composer/src/utils/convertToMarkdown/utils/getThreats/index.ts
+++ b/packages/threat-composer/src/utils/convertToMarkdown/utils/getThreats/index.ts
@@ -13,7 +13,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
+import { STATUS_NOT_SET } from '../../../../configs/status';
 import { DataExchangeFormat } from '../../../../customTypes';
+import threatStatus from '../../../../data/status/threatStatus.json';
 import escapeMarkdown from '../../../../utils/escapeMarkdown';
 import parseTableCellContent from '../../../../utils/parseTableCellContent';
 import standardizeNumericId from '../../../../utils/standardizeNumericId';
@@ -27,8 +29,8 @@ export const getThreatsContent = async (
 
   rows.push('\n');
 
-  rows.push(`| Threat Number | Threat | ${threatsOnly ? '' : 'Mitigations | Assumptions |'} Priority | STRIDE | Comments |`);
-  rows.push(`| --- | --- | ${threatsOnly ? '' : '--- | --- |'} --- | --- | --- |`);
+  rows.push(`| Threat Number | Threat | ${threatsOnly ? '' : 'Mitigations | Assumptions |'} Status | Priority | STRIDE | Comments |`);
+  rows.push(`| --- | --- | ${threatsOnly ? '' : '--- | --- |'} --- | --- | --- | --- |`);
 
   if (data.threats) {
     const promises = data.threats.map(async (x) => {
@@ -51,10 +53,11 @@ export const getThreatsContent = async (
         }
         return null;
       }).filter(ml => !!ml).join('<br/>');
+      const status = ( x.status && threatStatus.find(ts => ts.value === x.status)?.label ) || STATUS_NOT_SET;
       const priority = x.metadata?.find(m => m.key === 'Priority')?.value || '';
       const STRIDE = ((x.metadata?.find(m => m.key === 'STRIDE')?.value || []) as string[]).join(', ');
       const comments = await parseTableCellContent((x.metadata?.find(m => m.key === 'Comments')?.value as string) || '');
-      return `| <a name="${threatId}"></a>${threatId} | ${escapeMarkdown(x.statement || '')} | ${threatsOnly ? '' : `${mitigationsContent} | ${assumptionsContent} | `} ${priority} | ${STRIDE} | ${comments} |`;
+      return `| <a name="${threatId}"></a>${threatId} | ${escapeMarkdown(x.statement || '')} | ${threatsOnly ? '' : `${mitigationsContent} | ${assumptionsContent} | `} ${status} | ${priority} | ${STRIDE} | ${comments} |`;
     });
 
     rows.push(...(await Promise.all(promises)));

--- a/packages/threat-composer/src/utils/getNewAssumption/index.tsx
+++ b/packages/threat-composer/src/utils/getNewAssumption/index.tsx
@@ -13,17 +13,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-import { v4 as uuidV4 } from 'uuid';
-import { DEFAULT_THREAT_STATUS } from '../../configs/status';
-import { TemplateThreatStatement } from '../../customTypes';
+import { DEFAULT_NEW_ENTITY_ID } from '../../configs';
+import { Assumption } from '../../customTypes';
 
-const getNewThreatStatement = (): TemplateThreatStatement => {
+const getNewAssumption = (content: string = ''): Assumption => {
   return {
-    id: uuidV4(),
+    id: DEFAULT_NEW_ENTITY_ID,
     numericId: -1,
-    displayOrder: -1,
-    status: DEFAULT_THREAT_STATUS,
+    content: content,
   };
 };
 
-export default getNewThreatStatement;
+export default getNewAssumption;

--- a/packages/threat-composer/src/utils/getNewMitigation/index.tsx
+++ b/packages/threat-composer/src/utils/getNewMitigation/index.tsx
@@ -13,22 +13,17 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  ******************************************************************************************************************** */
-export const DEFAULT_MITIGATION_STATUS = 'mitigationIdentified';
-export const DEFAULT_THREAT_STATUS = 'threatIdentified';
-export const STATUS_NOT_SET = 'NoSet';
+import { DEFAULT_NEW_ENTITY_ID } from '../../configs';
+import { DEFAULT_MITIGATION_STATUS } from '../../configs/status';
+import { Mitigation } from '../../customTypes';
 
-export const MITIGATION_STATUS_COLOR_MAPPING: any = {
-  mitigationIdentified: 'grey',
-  mitigationInProgress: 'blue',
-  mitigationResolved: 'green',
-  mitigationResolvedAbandoned: 'red',
-  NotSet: 'grey',
+const getNewMitigation = (content: string = ''): Mitigation => {
+  return {
+    id: DEFAULT_NEW_ENTITY_ID,
+    numericId: -1,
+    status: DEFAULT_MITIGATION_STATUS,
+    content: content,
+  };
 };
 
-export const THREAT_STATUS_COLOR_MAPPING: any = {
-  threatIdentified: 'grey',
-  threatResolvedNotUseful: 'blue',
-  threatResolved: 'green',
-  NotSet: 'grey',
-};
-
+export default getNewMitigation;

--- a/packages/threat-composer/src/utils/getNewThreatStatement/index.tsx
+++ b/packages/threat-composer/src/utils/getNewThreatStatement/index.tsx
@@ -14,13 +14,14 @@
   limitations under the License.
  ******************************************************************************************************************** */
 import { v4 as uuidV4 } from 'uuid';
+import { DEFAULT_THREAT_STATUS } from '../../configs/status';
 import { TemplateThreatStatement } from '../../customTypes';
 
 const getNewThreatStatement = (): TemplateThreatStatement => {
   return {
     id: uuidV4(),
     numericId: -1,
-    status: 'threatIdentified',
+    status: DEFAULT_THREAT_STATUS,
   };
 };
 


### PR DESCRIPTION
*Issue #, if available:*

#61 
#126

*Description of changes:*

This PR is to 
1.  Allow users to set status for mitigations and threats
2. Update Threat Model Report to show status of mitigations and threats
3. Add mitigation status and threat status into Workspace Insight Dashboard

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
