### PR TITLE
fix(build): Restructure the workspace examples dynamic import name

### DIFF
--- a/scripts/data/injectData.ts
+++ b/scripts/data/injectData.ts
@@ -37,6 +37,8 @@ const WORKSPACE_EXAMPLE_FILE = path.join(
   "workspaceExamples.ts"
 );
 
+const WORKSPACE_EXPORT_PREFIX = "ThreatComposer_Workspace_";
+
 type DataType = "ThreatPack" | "MitigationPack" | "WorkspaceExample";
 
 const CONFIG_DATA_FOLDER = {
@@ -90,7 +92,11 @@ const injectDataEntry = (
       `${fileNames
         .map((fn) => {
           if (dataType === "WorkspaceExample") {
-            return `{ name: '${fn}', value: ${fn}, },`;
+            const name = fn
+              .replace(WORKSPACE_EXPORT_PREFIX, "")
+              .replace(/[_]+/gm, " ");
+
+            return `{ name: '${name}', value: ${fn}, },`;
           }
 
           return `${fn},`;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR is to update the injectData script to restructure the name of dynamically imported workspace examples from the file name. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
