### PR TITLE
fix(build): repair pdk yarn invocations

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,4 +4,4 @@ set -e
 
 pdk install --frozen-lockfile
 pdk build
-pdk workspaces run eslint
+pdk eslint

--- a/scripts/deployAll.sh
+++ b/scripts/deployAll.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+
 set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 ${SCRIPT_DIR}/build.sh
 
-pdk workspace @aws/threat-composer-infra run cdk deploy
+yarn workspace @aws/threat-composer-infra run cdk deploy

--- a/scripts/deployDev.sh
+++ b/scripts/deployDev.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 ${SCRIPT_DIR}/build.sh
 
-pdk workspace @aws/threat-composer-infra run cdk deploy Dev/ThreatComposerAppStack
+yarn workspace @aws/threat-composer-infra run cdk deploy Dev/ThreatComposerAppStack


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
In `build.sh`, the invocation to PDK had extra sets of tokens that were unneeded; I have removed those.

 In both `deployAll.sh` and `deployDev.sh`, `pdk` referred to projen tasks (`workspace`, `run`) that didn't exist; I have reverted the PDK invocation to use `yarn` instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
