### PR TITLE
fix(threat-composer-ai): handle None values in rich_escape to fix CLI startup crash

### DIFF
--- a/packages/threat-composer-ai/src/threat_composer_ai/logging/rich_logger.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/logging/rich_logger.py
@@ -5,8 +5,17 @@ from pathlib import Path
 
 from rich.console import Console
 from rich.logging import RichHandler
-from rich.markup import escape as rich_escape
+from rich.markup import escape as _rich_escape
 from rich.theme import Theme
+
+
+def rich_escape(value) -> str:
+    """Safely escape a value for Rich markup, handling None and non-string types."""
+    if value is None:
+        return "None"
+    if not isinstance(value, str):
+        value = str(value)
+    return _rich_escape(value)
 
 # Custom theme for threat-composer-ai
 THREAT_COMPOSER_THEME = Theme(


### PR DESCRIPTION
## Issue

Running `threat-composer-ai-cli` without a named AWS profile (i.e. using the default credentials chain) crashes immediately during the startup banner:

```
File ".../threat_composer_ai/logging/rich_logger.py", line 318, in log_startup_banner
    _log_markup(logger, logging.INFO, f"[success]  Profile: {rich_escape(config.aws_profile)} | Source: ...")
File ".../rich/markup.py", line 66, in escape
    markup = _escape(escape_backslashes, markup)
TypeError: expected string or bytes-like object, got 'NoneType'
```

`config.aws_profile` is `None` whenever `AWS_PROFILE` isn't set, which is a very common setup.

## Root cause

#246 wrapped banner values with `rich.markup.escape` to prevent markup-parsing errors. However, `rich.markup.escape` only accepts `str` and raises `TypeError` on `None`.

## Fix

Wrap `rich.markup.escape` with a safe `rich_escape` helper that:
- returns `"None"` for `None` inputs
- coerces non-string values via `str()` before escaping

All existing call sites continue to work unchanged.

## Verification

Before:
```
INFO     🔧 SYSTEM | ☁️  AWS CONFIGURATION
Traceback (most recent call last):
  ...
TypeError: expected string or bytes-like object, got 'NoneType'
```

After:
```
INFO     🔧 SYSTEM | ☁️  AWS CONFIGURATION
INFO     🔧 SYSTEM |   Profile: None | Source: not configured
INFO     🔧 SYSTEM |   Region: us-west-2 | Source: default
INFO     🔧 SYSTEM |   Model ID: global.anthropic.claude-sonnet-4-20250514-v1:0 | Source: default
...
INFO     🔧 SYSTEM | ✅ Analyzing directory: /path/to/workdir
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
