### PR TITLE
fix(threat-composer-ai): respect log level in _log_markup so DEBUG lines are suppressed at INFO

### DIFF
--- a/packages/threat-composer-ai/src/threat_composer_ai/logging/rich_logger.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/logging/rich_logger.py
@@ -223,6 +223,8 @@ def clear_agent_context() -> None:
 
 def _log_markup(logger, level, message):
     """Log a message that contains pre-escaped Rich markup tags."""
+    if not logger.isEnabledFor(level):
+        return
     record = logger.makeRecord(
         logger.name, level, "(unknown)", 0, message, (), None
     )


### PR DESCRIPTION
## Issue

After #268 fixed the startup banner crash, running the CLI still emits `DEBUG` lines even though `--verbose` is not set and the banner reports `Verbose Logging: False`:

```
INFO     🔧 SYSTEM |   Verbose Logging: False
...
DEBUG    🔧 SYSTEM | 🔍 Checking Graphviz installation
DEBUG    🔧 SYSTEM | 🔍 Graphviz found at: /opt/homebrew/bin/dot
DEBUG    🔧 SYSTEM | 🔍 Starting AWS Bedrock credential validation
DEBUG    🔧 SYSTEM | 🔍 Listing diagram icons - provider: aws, service: compute
...
```

## Root cause

#246 introduced the `_log_markup` helper that routes all `log_info` / `log_debug` / `log_success` / etc. calls through `logger.handle(record)` instead of `logger.debug(msg)` / `logger.info(msg)`.

Per the Python `logging` docs, `Logger.handle()` is called **after** level filtering — it does not run `isEnabledFor()` itself. The convenience methods (`logger.debug`, `logger.info`, etc.) perform that check before calling `handle()`. As a result, `_log_markup` emits every record regardless of the configured log level, and `DEBUG` lines always print.

Before #246, `log_debug(...)` called `logger.debug(...)` directly and was correctly suppressed at `INFO` level.

## Fix

Add an explicit `isEnabledFor(level)` guard in `_log_markup`. This restores the expected behavior: `DEBUG` lines only appear when `--verbose` is set.

## Verification

```
threat-composer-ai-cli . --enable-telemetry
# (no --verbose)
```

Before:
```
INFO     🔧 SYSTEM |   Verbose Logging: False
DEBUG    🔧 SYSTEM | 🔍 Checking Graphviz installation
DEBUG    🔧 SYSTEM | 🔍 Starting AWS Bedrock credential validation
...
```

After:
```
INFO     🔧 SYSTEM |   Verbose Logging: False
INFO     🔧 SYSTEM | ✅ Graphviz installation validated
INFO     🔧 SYSTEM | ✅ AWS Bedrock credentials validated successfully
...
```

With `--verbose`, `DEBUG` lines appear as before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
