### PR TITLE
fix: omit temperature param for models that don't support sampling

### DIFF
--- a/packages/threat-composer-ai/src/threat_composer_ai/agents/common.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/agents/common.py
@@ -276,6 +276,12 @@ def create_enhanced_boto_config() -> BotocoreConfig:
     )
 
 
+# Module-level cache: tracks model IDs that have rejected sampling parameters.
+# Populated at runtime when a model returns a "temperature is deprecated" error,
+# so no hardcoded model list is needed.
+_models_without_sampling_support: set[str] = set()
+
+
 def create_default_bedrock_model(
     model_id: str | None = None,
     region_name: str | None = None,
@@ -287,10 +293,15 @@ def create_default_bedrock_model(
     """
     Create a default BedrockModel configuration for threat modeling agents.
 
+    Automatically detects models that don't support sampling parameters
+    (temperature, top_p, top_k). On the first call for a given model, if the
+    API rejects the temperature parameter, the model ID is cached and all
+    subsequent calls for that model will omit sampling params without retrying.
+
     Args:
         model_id: Model ID to use (defaults to config or Claude)
         region_name: AWS region (defaults to config or us-west-2)
-        temperature: Model temperature (0.3 for focused analysis)
+        temperature: Model temperature (0.3 for focused analysis, ignored for models that don't support it)
         max_tokens: Maximum tokens (16384 for comprehensive analysis)
         config: Optional AppConfig for default values
         **kwargs: Additional model parameters
@@ -305,6 +316,8 @@ def create_default_bedrock_model(
     default_region = config.aws_region
     profile = config.aws_profile if config else None
 
+    resolved_model_id = model_id or default_model_id
+
     # Create boto session with profile if specified
     boto_session = None
     if profile:
@@ -315,12 +328,18 @@ def create_default_bedrock_model(
     # Build model parameters conditionally
     # When boto_session is provided, don't pass region_name (they're mutually exclusive)
     model_params = {
-        "model_id": model_id or default_model_id,
+        "model_id": resolved_model_id,
         "cache_tools": "default",
         "boto_client_config": create_enhanced_boto_config(),
-        "temperature": temperature,
         "max_tokens": max_tokens,
     }
+
+    # Only include temperature if this model hasn't previously rejected it.
+    # Models like Claude Opus 4.7+ return a 400 ValidationException when
+    # sampling params are provided. The cache is populated by
+    # mark_model_no_sampling_support() when that error is detected.
+    if resolved_model_id not in _models_without_sampling_support:
+        model_params["temperature"] = temperature
 
     if boto_session:
         model_params["boto_session"] = boto_session
@@ -328,6 +347,20 @@ def create_default_bedrock_model(
         model_params["region_name"] = region_name or default_region
 
     return BedrockModel(**model_params, **kwargs)
+
+
+def mark_model_no_sampling_support(model_id: str) -> None:
+    """
+    Record that a model does not support sampling parameters.
+
+    Call this when a model returns a ValidationException indicating that
+    temperature/top_p/top_k is deprecated. All future BedrockModel instances
+    for this model ID will omit sampling parameters automatically.
+
+    Args:
+        model_id: The Bedrock model ID that rejected sampling params
+    """
+    _models_without_sampling_support.add(model_id)
 
 
 def create_default_conversation_manager():

--- a/packages/threat-composer-ai/src/threat_composer_ai/validation/aws_validator.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/validation/aws_validator.py
@@ -10,7 +10,7 @@ from botocore.exceptions import (
 )
 from strands import Agent
 
-from ..agents.common import create_agent_model
+from ..agents.common import create_agent_model, mark_model_no_sampling_support
 from ..config import AppConfig
 from ..logging import log_debug, log_error, log_success, log_warning
 
@@ -67,6 +67,12 @@ def get_aws_credential_info(config: AppConfig) -> dict[str, str]:
         }
 
 
+def _is_sampling_param_error(error: Exception) -> bool:
+    """Check if an exception is caused by unsupported sampling parameters."""
+    msg = str(error).lower()
+    return "temperature" in msg and "deprecated" in msg
+
+
 def validate_aws_bedrock_inference(config: AppConfig) -> bool:
     """ """
     try:
@@ -80,6 +86,25 @@ def validate_aws_bedrock_inference(config: AppConfig) -> bool:
         return True
 
     except Exception as e:
+        if _is_sampling_param_error(e):
+            # Model doesn't support sampling params — cache this and retry without them
+            log_warning(
+                f"Model {config.aws_model_id} does not support sampling parameters, retrying without temperature"
+            )
+            mark_model_no_sampling_support(config.aws_model_id)
+            try:
+                agent = Agent(
+                    system_prompt="You like pineapple on your pizza.",
+                    model=create_agent_model("test", config),
+                    callback_handler=None,
+                )
+                agent("Testing...")
+                log_success("Inference validated successfully (without sampling params)")
+                return True
+            except Exception as retry_err:
+                log_error(f"Inference validation failed on retry: {str(retry_err)}")
+                return False
+
         log_error(f"Inference validation failed: {str(e)}")
         return False
 


### PR DESCRIPTION
Issue: https://github.com/awslabs/threat-composer/issues/272

*Issue #, if available:*
272

*Description of changes:*

Claude Opus 4.7+ returns a 400 ValidationException when temperature, top_p, or top_k are provided. Instead of maintaining a hardcoded model list, use runtime detection: if the inference validation call fails with a 'temperature is deprecated' error, cache the model ID and retry without sampling params. All subsequent BedrockModel instances for that model automatically omit temperature for the rest of the process.

### Before
```
                    ERROR    🔧 SYSTEM | ❌ Inference validation failed: An error occurred   
                             (ValidationException) when calling the ConverseStream operation:
                             The model returned the following errors:                        
                             {"type":"error","request_id":"req_4fikq5mo2fmlmtfy5yfkajx7ardupy
                             3pmizwj33q7i7wxmtolffq","error":{"type":"invalid_request_error",
                             "message":"`temperature` is deprecated for this model."}}       
                    ERROR    🔧 SYSTEM | ❌ Setup failed: AWS Bedrock inference validation   
                             failed
```

### After

#### Opus 4.7
```
[04/23/26 16:18:26] WARNING  🔧 SYSTEM | ⚠️  Model us.anthropic.claude-opus-4-7 does not      
                             support sampling parameters, retrying without temperature       
[04/23/26 16:18:37] INFO     🔧 SYSTEM | ✅ Inference validated successfully (without        
                             sampling params)                        
```

#### Opus 4.6
```
[04/23/26 16:21:16] INFO     🔧 SYSTEM | ✅ Inference validated successfully                 
```

#### Sonnet 4 (default)
```
[04/23/26 16:22:09] INFO     🔧 SYSTEM | ✅ Inference validated successfully                 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
