### PR TITLE
fix: prune gitignored directories during walk and fix subdirectory pattern anchoring

### DIFF
--- a/packages/threat-composer-ai/src/threat_composer_ai/tools/threat_composer_list_workdir_files_gitignore_filtered.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/tools/threat_composer_list_workdir_files_gitignore_filtered.py
@@ -60,10 +60,15 @@ def load_gitignore_patterns(
                     adjusted_patterns = []
                     for pattern in patterns:
                         if pattern.startswith("!"):
-                            # Negation pattern
-                            adjusted_patterns.append(f"!{relative_dir}/{pattern[1:]}")
+                            # Negation pattern - strip leading '/' since the
+                            # relative_dir prefix already anchors the pattern
+                            clean = pattern[1:].lstrip("/")
+                            adjusted_patterns.append(f"!{relative_dir}/{clean}")
                         else:
-                            adjusted_patterns.append(f"{relative_dir}/{pattern}")
+                            # Strip leading '/' from anchored patterns (e.g. "/node_modules")
+                            # since prepending relative_dir already provides anchoring
+                            clean = pattern.lstrip("/")
+                            adjusted_patterns.append(f"{relative_dir}/{clean}")
                     all_patterns.extend(adjusted_patterns)
                 else:
                     all_patterns.extend(patterns)
@@ -134,11 +139,48 @@ def get_hardcoded_exclusions(working_directory: Path) -> pathspec.PathSpec:
     return pathspec.PathSpec.from_lines("gitwildmatch", hardcoded_patterns)
 
 
+def _negated_prefixes(gitignore_spec: pathspec.PathSpec | None) -> set[str]:
+    """Extract directory prefixes that have negation patterns underneath them.
+
+    If a gitignore contains '!node_modules/special-package', we must not prune
+    'node_modules' during the walk — the negation needs the full file list to apply.
+
+    Returns all ancestor directory paths of negated patterns so that pruning
+    checks at any depth will find a match. For example, '!subdir/node_modules/pkg'
+    produces {'subdir', 'subdir/node_modules'}.
+
+    Note: This accesses pathspec internal attributes (pattern.regex, pattern.pattern)
+    which are not part of the public API. Defensive getattr calls are used to avoid
+    breakage on pathspec version bumps. Tested against pathspec >=0.11.
+    """
+    if not gitignore_spec:
+        return set()
+    prefixes = set()
+    for pattern in gitignore_spec.patterns:
+        if getattr(pattern, "regex", None) and getattr(pattern, "pattern", None):
+            raw = getattr(pattern, "pattern", "")
+            if raw.startswith("!"):
+                clean = raw[1:].lstrip("/")
+                parts = clean.split("/")
+                # Add ancestor directory paths (exclude the leaf which is typically
+                # a file or the target itself, not a directory to preserve)
+                for i in range(1, len(parts)):
+                    prefixes.add("/".join(parts[:i]))
+    return prefixes
+
+
 def collect_files(
-    directory: Path, include_hidden: bool, follow_symlinks: bool
+    directory: Path,
+    include_hidden: bool,
+    follow_symlinks: bool,
+    gitignore_spec: pathspec.PathSpec | None = None,
+    hardcoded_spec: pathspec.PathSpec | None = None,
 ) -> list[Path]:
-    """Collect all files in the directory tree."""
+    """Collect all files in the directory tree, pruning ignored directories during walk."""
     files = []
+    # Pre-compute directories that have negation patterns referencing their contents.
+    # These directories must NOT be pruned so the negation can be evaluated file-by-file.
+    negated = _negated_prefixes(gitignore_spec)
 
     try:
         for root, dirs, filenames in os.walk(directory, followlinks=follow_symlinks):
@@ -149,6 +191,33 @@ def collect_files(
             if not include_hidden:
                 # Remove any directory that starts with a dot
                 dirs[:] = [d for d in dirs if not d.startswith(".")]
+
+            # Prune directories that match gitignore or hardcoded exclusion patterns.
+            # This prevents os.walk from descending into ignored directories (e.g.
+            # node_modules), avoiding the cost of traversing potentially tens of
+            # thousands of files that would be filtered out later anyway.
+            # Directories with negation patterns underneath them are kept so that
+            # the negation can be evaluated file-by-file during the filter pass.
+            if gitignore_spec or hardcoded_spec:
+                surviving_dirs = []
+                for d in dirs:
+                    try:
+                        rel_dir = str((root_path / d).relative_to(directory)).replace(
+                            "\\", "/"
+                        )
+                    except ValueError:
+                        surviving_dirs.append(d)
+                        continue
+                    # Don't prune if any negation pattern references this directory
+                    if rel_dir in negated:
+                        surviving_dirs.append(d)
+                        continue
+                    if gitignore_spec and gitignore_spec.match_file(rel_dir + "/"):
+                        continue
+                    if hardcoded_spec and hardcoded_spec.match_file(rel_dir + "/"):
+                        continue
+                    surviving_dirs.append(d)
+                dirs[:] = surviving_dirs
 
             # Add files
             for filename in filenames:
@@ -257,8 +326,10 @@ def threat_composer_list_workdir_files_gitignore_filtered(
         # Get hardcoded exclusions
         hardcoded_spec = get_hardcoded_exclusions(directory)
 
-        # Collect all files
-        all_files = collect_files(directory, include_hidden, follow_symlinks)
+        # Collect all files, pruning ignored directories during the walk
+        all_files = collect_files(
+            directory, include_hidden, follow_symlinks, gitignore_spec, hardcoded_spec
+        )
 
         # Filter files against patterns
         filtered_files = []

--- a/packages/threat-composer-ai/tests/tools/test_gitignore_filtering.py
+++ b/packages/threat-composer-ai/tests/tools/test_gitignore_filtering.py
@@ -1,0 +1,191 @@
+"""Tests for gitignore filtering and directory pruning in the file listing tool."""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pathspec
+import pytest
+
+from threat_composer_ai.tools.threat_composer_list_workdir_files_gitignore_filtered import (
+    _negated_prefixes,
+    collect_files,
+    find_gitignore_files,
+    get_hardcoded_exclusions,
+    load_gitignore_patterns,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests and clean up after."""
+    d = tempfile.mkdtemp()
+    yield Path(d)
+    shutil.rmtree(d)
+
+
+def _create_file(base: Path, rel_path: str, content: str = "x") -> Path:
+    """Helper to create a file with parent directories."""
+    fp = base / rel_path
+    fp.parent.mkdir(parents=True, exist_ok=True)
+    fp.write_text(content)
+    return fp
+
+
+class TestLoadGitignorePatterns:
+    """Tests for subdirectory .gitignore pattern adjustment."""
+
+    def test_root_gitignore_patterns_unchanged(self, temp_dir):
+        _create_file(temp_dir, ".gitignore", "node_modules\n*.log\n")
+        gi_files = find_gitignore_files(temp_dir)
+        spec = load_gitignore_patterns(gi_files, temp_dir)
+        assert spec.match_file("node_modules/pkg/index.js")
+        assert spec.match_file("error.log")
+        assert not spec.match_file("src/app.py")
+
+    def test_subdirectory_anchored_pattern_stripped(self, temp_dir):
+        """Leading '/' in subdirectory .gitignore should be stripped."""
+        _create_file(temp_dir, "subdir/.gitignore", "/node_modules\n/dist\n")
+        _create_file(temp_dir, "subdir/app.js")
+        gi_files = find_gitignore_files(temp_dir)
+        spec = load_gitignore_patterns(gi_files, temp_dir)
+        # Should match: subdir/node_modules (not subdir//node_modules)
+        assert spec.match_file("subdir/node_modules")
+        assert spec.match_file("subdir/dist")
+        assert not spec.match_file("subdir/app.js")
+
+    def test_subdirectory_unanchored_pattern(self, temp_dir):
+        """Patterns without leading '/' should also work in subdirectories."""
+        _create_file(temp_dir, "subdir/.gitignore", "*.pyc\n__pycache__\n")
+        gi_files = find_gitignore_files(temp_dir)
+        spec = load_gitignore_patterns(gi_files, temp_dir)
+        assert spec.match_file("subdir/module.pyc")
+        assert spec.match_file("subdir/__pycache__")
+
+    def test_subdirectory_negation_pattern(self, temp_dir):
+        _create_file(temp_dir, "subdir/.gitignore", "/node_modules\n!node_modules/keep\n")
+        gi_files = find_gitignore_files(temp_dir)
+        spec = load_gitignore_patterns(gi_files, temp_dir)
+        # node_modules is ignored
+        assert spec.match_file("subdir/node_modules/pkg/index.js")
+        # but the negation re-includes "keep"
+        assert not spec.match_file("subdir/node_modules/keep")
+
+
+class TestNegatedPrefixes:
+    """Tests for _negated_prefixes extraction."""
+
+    def test_no_negations_returns_empty(self):
+        spec = pathspec.PathSpec.from_lines("gitwildmatch", ["node_modules", "dist"])
+        assert _negated_prefixes(spec) == set()
+
+    def test_extracts_ancestor_directories(self):
+        spec = pathspec.PathSpec.from_lines(
+            "gitwildmatch", ["node_modules", "!node_modules/special"]
+        )
+        prefixes = _negated_prefixes(spec)
+        assert "node_modules" in prefixes
+
+    def test_nested_negation_extracts_all_ancestors(self):
+        spec = pathspec.PathSpec.from_lines(
+            "gitwildmatch", ["!subdir/node_modules/special"]
+        )
+        prefixes = _negated_prefixes(spec)
+        assert "subdir" in prefixes
+        assert "subdir/node_modules" in prefixes
+        # Leaf should NOT be included
+        assert "subdir/node_modules/special" not in prefixes
+
+    def test_none_spec_returns_empty(self):
+        assert _negated_prefixes(None) == set()
+
+
+class TestCollectFilesWithPruning:
+    """Tests for directory pruning during os.walk."""
+
+    def test_prunes_gitignored_directory(self, temp_dir):
+        _create_file(temp_dir, "src/app.py")
+        _create_file(temp_dir, "node_modules/pkg/index.js")
+        _create_file(temp_dir, ".gitignore", "node_modules\n")
+        gi_files = find_gitignore_files(temp_dir)
+        gi_spec = load_gitignore_patterns(gi_files, temp_dir)
+        hc_spec = get_hardcoded_exclusions(temp_dir)
+
+        files = collect_files(temp_dir, False, False, gi_spec, hc_spec)
+        rel_paths = {str(f.relative_to(temp_dir)) for f in files}
+
+        assert "src/app.py" in rel_paths
+        # node_modules should be pruned — its files should not appear
+        assert "node_modules/pkg/index.js" not in rel_paths
+
+    def test_negation_prevents_pruning(self, temp_dir):
+        _create_file(temp_dir, "node_modules/regular/index.js")
+        _create_file(temp_dir, "node_modules/special/index.js")
+        _create_file(temp_dir, "src/app.py")
+        _create_file(temp_dir, ".gitignore", "node_modules\n!node_modules/special\n")
+        gi_files = find_gitignore_files(temp_dir)
+        gi_spec = load_gitignore_patterns(gi_files, temp_dir)
+        hc_spec = get_hardcoded_exclusions(temp_dir)
+
+        files = collect_files(temp_dir, False, False, gi_spec, hc_spec)
+        rel_paths = {str(f.relative_to(temp_dir)) for f in files}
+
+        # node_modules should NOT be pruned because of the negation
+        # (both files will be in the collected set; filtering happens later)
+        assert "node_modules/special/index.js" in rel_paths
+        assert "src/app.py" in rel_paths
+
+    def test_hardcoded_exclusions_pruned(self, temp_dir):
+        _create_file(temp_dir, "src/app.py")
+        _create_file(temp_dir, ".git/config", "x")
+        _create_file(temp_dir, "cdk.out/manifest.json")
+        hc_spec = get_hardcoded_exclusions(temp_dir)
+
+        files = collect_files(temp_dir, False, False, None, hc_spec)
+        rel_paths = {str(f.relative_to(temp_dir)) for f in files}
+
+        assert "src/app.py" in rel_paths
+        assert ".git/config" not in rel_paths
+        assert "cdk.out/manifest.json" not in rel_paths
+
+    def test_no_specs_collects_everything(self, temp_dir):
+        _create_file(temp_dir, "src/app.py")
+        _create_file(temp_dir, "node_modules/pkg/index.js")
+
+        files = collect_files(temp_dir, False, False, None, None)
+        rel_paths = {str(f.relative_to(temp_dir)) for f in files}
+
+        assert "src/app.py" in rel_paths
+        assert "node_modules/pkg/index.js" in rel_paths
+
+    def test_subdirectory_gitignore_with_negation(self, temp_dir):
+        """End-to-end: subdirectory .gitignore with anchored pattern + negation."""
+        _create_file(temp_dir, "subdir/src/app.js")
+        _create_file(temp_dir, "subdir/node_modules/regular/index.js")
+        _create_file(temp_dir, "subdir/node_modules/special/index.js")
+        _create_file(
+            temp_dir, "subdir/.gitignore", "/node_modules\n!node_modules/special\n"
+        )
+        _create_file(temp_dir, "root.txt")
+
+        gi_files = find_gitignore_files(temp_dir)
+        gi_spec = load_gitignore_patterns(gi_files, temp_dir)
+        hc_spec = get_hardcoded_exclusions(temp_dir)
+
+        all_files = collect_files(temp_dir, False, False, gi_spec, hc_spec)
+
+        # Apply the same filter as the main tool
+        result = []
+        for fp in all_files:
+            rel = str(fp.relative_to(temp_dir)).replace("\\", "/")
+            if gi_spec.match_file(rel):
+                continue
+            if hc_spec.match_file(rel):
+                continue
+            result.append(rel)
+
+        assert "root.txt" in result
+        assert "subdir/src/app.js" in result
+        assert "subdir/node_modules/special/index.js" in result
+        assert "subdir/node_modules/regular/index.js" not in result


### PR DESCRIPTION
Issue: https://github.com/awslabs/threat-composer/issues/274

*Issue #, if available:*
274

*Description of changes:*
Two fixes for the file listing tool:

1. Fix subdirectory .gitignore pattern adjustment: patterns with a leading '/' (e.g. '/node_modules') were being prepended with the relative directory path without stripping the slash, producing broken patterns like 'subdir//node_modules' that pathspec couldn't match. Now strips the leading '/' before prepending the relative directory prefix.

2. Prune ignored directories during os.walk: previously, all files were collected first and then filtered against gitignore/hardcoded patterns. This meant the tool would walk entire ignored directory trees (e.g. 30K+ files in node_modules) only to discard them. Now the exclusion specs are passed to collect_files() which prunes matching directories in-place during the walk, preventing descent into ignored subtrees. Pruning is negation-aware: directories referenced by ! patterns are kept so the negation can be evaluated file-by-file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
