### PR TITLE
Fix Dockerfile to work with threat-composer-ai

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,12 @@ RUN nvm install $NODE_VERSION
 # Required to build the threat-composer app
 RUN npm install -g @aws/pdk yarn
 
+# Graphviz needed by the threat-composer-ai package (installed as root)
+RUN dnf install -y graphviz && dnf clean all
+
+# uv (required by packages/threat-composer-ai postinstall hook)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 # Create a non-root user named 'app' and set up home directory
 RUN useradd -m app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:latest as build
 
-RUN dnf install tar gzip python3 gcc-c++ make python3-pip rsync shadow-utils -y
+RUN dnf install tar gzip python3 gcc-c++ make python3-pip rsync shadow-utils graphviz -y
 
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 20
@@ -22,11 +22,8 @@ RUN nvm install $NODE_VERSION
 # Required to build the threat-composer app
 RUN npm install -g @aws/pdk yarn
 
-# Graphviz needed by the threat-composer-ai package (installed as root)
-RUN dnf install -y graphviz && dnf clean all
-
 # uv (required by packages/threat-composer-ai postinstall hook)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.26 /uv /uvx /usr/local/bin/
 
 # Create a non-root user named 'app' and set up home directory
 RUN useradd -m app


### PR DESCRIPTION
When trying to run Threat Composer locally from the Dockerfile, I was getting this error below

```
threat-composer-ai: /bin/sh: line 1: uv: command not found
```

*Description of changes:*

I have resolved this by installing `graphviz` and `uv`, both required dependencies of threat-composer-ai. The Dockerfile installs UV from their ghcr at the tag `latest`, if you need this pinned to a specific version let me know and I can make the change.

This PR fixes the Dockerfile and makes it run again.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.