### PR TITLE
feat: Update default model to Claude Sonnet 4.5

### DIFF
--- a/docs/AI-CLI-MCP.md
+++ b/docs/AI-CLI-MCP.md
@@ -59,7 +59,7 @@ Without the extension, you can still view and edit the generated JSON files as t
 
 Threat Composer AI uses **Amazon Bedrock** for AI inference, which incurs costs based on token usage. By default, the tool uses:
 
-- **Model**: Claude Sonnet 4 (`global.anthropic.claude-sonnet-4-20250514-v1:0`)
+- **Model**: Claude Sonnet 4.5 (`global.anthropic.claude-sonnet-4-5-20250929-v1:0`)
 - **Service Tier**: Standard on-demand (default)
 
 **Estimated costs** vary based on codebase size and complexity. A typical threat model generation may use 500,000-1,500,000+ tokens depending on the project.

--- a/packages/threat-composer-ai/src/threat_composer_ai/config/app_config.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/config/app_config.py
@@ -56,7 +56,7 @@ class AppConfig:
 
     # AWS configuration
     aws_region: str = "us-west-2"
-    aws_model_id: str = "global.anthropic.claude-sonnet-4-20250514-v1:0"
+    aws_model_id: str = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
     aws_profile: str | None = None
 
     # Runtime configuration


### PR DESCRIPTION
Claude Sonnet 4 (`anthropic.claude-sonnet-4-20250514-v1:0`) entered Legacy state on Amazon Bedrock on April 14, 2026 and will reach End of Life on October 14, 2026 - [Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html). This PR migrates the default model to Claude Sonnet 4.5 (`global.anthropic.claude-sonnet-4-5-20250929-v1:0`).

Changes:
- Updated default `aws_model_id` in `app_config.py`
- Updated model reference in `docs/AI-CLI-MCP.md`

Users can still override via `--aws-model-id` CLI flag or `THREAT_COMPOSER_AWS_MODEL_ID` env var.

Tested: CLI runs end-to-end with the new model ID against Bedro