### PR TITLE
feat(ai): Resolve sampling params and output budget per model

### DIFF
--- a/docs/AI-CLI-MCP.md
+++ b/docs/AI-CLI-MCP.md
@@ -59,8 +59,10 @@ Without the extension, you can still view and edit the generated JSON files as t
 
 Threat Composer AI uses **Amazon Bedrock** for AI inference, which incurs costs based on token usage. By default, the tool uses:
 
-- **Model**: Claude Sonnet 4.5 (`global.anthropic.claude-sonnet-4-5-20250929-v1:0`)
+- **Model**: Claude Sonnet 5 (`global.anthropic.claude-sonnet-5`)
 - **Service Tier**: Standard on-demand (default)
+
+Claude Sonnet 5 always applies adaptive reasoning. Reasoning tokens are billed as output tokens, so output usage is higher than for a model without reasoning.
 
 **Estimated costs** vary based on codebase size and complexity. A typical threat model generation may use 500,000-1,500,000+ tokens depending on the project.
 
@@ -155,7 +157,7 @@ threat-composer-ai-cli /path/to/codebase \
   --output-dir ./analysis-results \
   --aws-profile pineapple
   --aws-region us-west-2 \
-  --aws-model-id global.anthropic.claude-sonnet-4-5-20250929-v1:0 \
+  --aws-model-id global.anthropic.claude-sonnet-5 \
 
 # Basic usage with uvx
 uvx --from "git+https://github.com/awslabs/threat-composer.git#subdirectory=packages/threat-composer-ai" threat-composer-ai-cli /path/to/codebase

--- a/packages/threat-composer-ai/src/threat_composer_ai/agents/common.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/agents/common.py
@@ -20,6 +20,10 @@ from strands.models import BedrockModel
 from strands.types.content import SystemContentBlock
 
 from ..config import AppConfig
+from ..config.model_capabilities import (
+    accepts_sampling_params,
+    resolve_max_output_tokens,
+)
 from ..logging import create_strands_rich_handler
 from ..tools import threat_composer_list_workdir_files_gitignore_filtered
 from ..tools.threat_composer_generate_uuid4 import (
@@ -276,33 +280,30 @@ def create_enhanced_boto_config() -> BotocoreConfig:
     )
 
 
-# Module-level cache: tracks model IDs that have rejected sampling parameters.
-# Populated at runtime when a model returns a "temperature is deprecated" error,
-# so no hardcoded model list is needed.
-_models_without_sampling_support: set[str] = set()
-
-
 def create_default_bedrock_model(
     model_id: str | None = None,
     region_name: str | None = None,
     temperature: float = 0.3,
-    max_tokens: int = 16384,
+    max_tokens: int = 32768,
     config: AppConfig | None = None,
     **kwargs,
 ) -> BedrockModel:
     """
     Create a default BedrockModel configuration for threat modeling agents.
 
-    Automatically detects models that don't support sampling parameters
-    (temperature, top_p, top_k). On the first call for a given model, if the
-    API rejects the temperature parameter, the model ID is cached and all
-    subsequent calls for that model will omit sampling params without retrying.
+    Sampling parameters and the output budget are both resolved per model via
+    config.model_capabilities, so pointing an agent at a different model cannot
+    produce a request that model rejects:
+
+    - temperature is omitted for models that reject sampling parameters
+    - max_tokens is clamped to the model's output ceiling
 
     Args:
         model_id: Model ID to use (defaults to config or Claude)
         region_name: AWS region (defaults to config or us-west-2)
-        temperature: Model temperature (0.3 for focused analysis, ignored for models that don't support it)
-        max_tokens: Maximum tokens (16384 for comprehensive analysis)
+        temperature: Model temperature (0.3 for focused analysis, omitted for
+            models that reject sampling parameters)
+        max_tokens: Desired maximum output tokens, clamped to the model ceiling
         config: Optional AppConfig for default values
         **kwargs: Additional model parameters
 
@@ -331,14 +332,13 @@ def create_default_bedrock_model(
         "model_id": resolved_model_id,
         "cache_tools": "default",
         "boto_client_config": create_enhanced_boto_config(),
-        "max_tokens": max_tokens,
+        "max_tokens": resolve_max_output_tokens(resolved_model_id, max_tokens),
     }
 
-    # Only include temperature if this model hasn't previously rejected it.
-    # Models like Claude Opus 4.7+ return a 400 ValidationException when
-    # sampling params are provided. The cache is populated by
-    # mark_model_no_sampling_support() when that error is detected.
-    if resolved_model_id not in _models_without_sampling_support:
+    # Omitted for models that reject a non-default temperature with a 400
+    # (Sonnet 5, Opus 4.7+). Resolved from the capability registry, which also
+    # honours anything the pre-flight probe learned at runtime.
+    if accepts_sampling_params(resolved_model_id):
         model_params["temperature"] = temperature
 
     if boto_session:
@@ -347,20 +347,6 @@ def create_default_bedrock_model(
         model_params["region_name"] = region_name or default_region
 
     return BedrockModel(**model_params, **kwargs)
-
-
-def mark_model_no_sampling_support(model_id: str) -> None:
-    """
-    Record that a model does not support sampling parameters.
-
-    Call this when a model returns a ValidationException indicating that
-    temperature/top_p/top_k is deprecated. All future BedrockModel instances
-    for this model ID will omit sampling parameters automatically.
-
-    Args:
-        model_id: The Bedrock model ID that rejected sampling params
-    """
-    _models_without_sampling_support.add(model_id)
 
 
 def create_default_conversation_manager():
@@ -386,45 +372,54 @@ def get_agent_model_config(
     Returns:
         Dictionary of model configuration parameters
     """
-    # Base configuration
+    # max_tokens is the budget an agent WANTS. It is clamped to the model's
+    # ceiling by resolve_max_output_tokens() when the model is built, so a value
+    # here may exceed what a smaller model accepts without breaking that model.
+    #
+    # Budgets are generous because requesting a high cap is free: Bedrock bills
+    # actual output, not the requested maximum, while under-requesting risks
+    # truncation. Truncation is expensive - on a tool-calling agent it surfaces
+    # as MaxTokensReachedException, which Strands treats as unrecoverable and
+    # which fails the whole run. Reasoning models make this sharper still, since
+    # thinking tokens are drawn from this same budget.
     base_config = {
         "temperature": 0.3,
-        "max_tokens": 16384,
+        "max_tokens": 32768,
     }
 
     # Agent-specific optimizations
     agent_configs = {
         "application_info": {
             "temperature": 0.5,  # More creative for discovering patterns
-            "max_tokens": 16384,  # Large for comprehensive repo analysis
+            "max_tokens": 32768,  # Large for comprehensive repo analysis
         },
         "architecture": {
             "temperature": 0.5,  # More creative for discovering patterns
-            "max_tokens": 16384,  # Large for comprehensive repo analysis
+            "max_tokens": 32768,  # Large for comprehensive repo analysis
         },
         "architecture_diagram": {
             "temperature": 0.1,  # Very focused
-            "max_tokens": 16384,
+            "max_tokens": 32768,
         },
         "dataflow": {
             "temperature": 0.5,  # More creative for discovering patterns
-            "max_tokens": 16384,
+            "max_tokens": 32768,
         },
         "dataflow_diagram": {
             "temperature": 0.1,  # Very focused
-            "max_tokens": 32768,  # Passing around a bunch of things
+            "max_tokens": 100_000,  # Passing around a bunch of things
         },
         "threats": {
             "temperature": 0.2,  # Very focused for systematic STRIDE analysis
-            "max_tokens": 32768,
+            "max_tokens": 100_000,  # Largest output in the pipeline
         },
         "mitigations": {
             "temperature": 0.6,  # Some creatively
-            "max_tokens": 16384,
+            "max_tokens": 32768,
         },
         "threat_model": {
             "temperature": 0.1,  # Very precise for schema generation
-            "max_tokens": 8192,  # small mostly deterministic stuff
+            "max_tokens": 16384,  # small mostly deterministic stuff
         },
     }
 

--- a/packages/threat-composer-ai/src/threat_composer_ai/config/__init__.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/config/__init__.py
@@ -11,9 +11,25 @@ from .global_config import (
     validate_path_in_output_directory,
     validate_path_security,
 )
+from .model_capabilities import (
+    ModelCapabilities,
+    accepts_sampling_params,
+    is_known_model,
+    is_sampling_param_error,
+    mark_model_no_sampling_support,
+    model_capabilities,
+    resolve_max_output_tokens,
+)
 
 __all__ = [
     "AppConfig",
+    "ModelCapabilities",
+    "model_capabilities",
+    "accepts_sampling_params",
+    "mark_model_no_sampling_support",
+    "resolve_max_output_tokens",
+    "is_sampling_param_error",
+    "is_known_model",
     "register_global_config",
     "get_global_config",
     "get_global_working_directory",

--- a/packages/threat-composer-ai/src/threat_composer_ai/config/app_config.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/config/app_config.py
@@ -56,7 +56,7 @@ class AppConfig:
 
     # AWS configuration
     aws_region: str = "us-west-2"
-    aws_model_id: str = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    aws_model_id: str = "global.anthropic.claude-sonnet-5"
     aws_profile: str | None = None
 
     # Runtime configuration

--- a/packages/threat-composer-ai/src/threat_composer_ai/config/model_capabilities.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/config/model_capabilities.py
@@ -1,0 +1,219 @@
+"""Per-model capability registry for Bedrock inference configuration.
+
+Bedrock exposes no API for per-model limits. ``GetFoundationModel`` returns
+modalities, streaming support and lifecycle only, and the API reference for
+inference configuration states that the documented parameter ranges are
+arbitrary and the real limits must be taken from the specific model. Model
+capabilities therefore have to be declared, which is why this module exists.
+
+Two capabilities affect every agent this package builds:
+
+``accepts_sampling_params``
+    Newer Anthropic models reject a non-default ``temperature`` / ``top_p`` /
+    ``top_k`` with a 400 ``ValidationException`` rather than ignoring it.
+    botocore does not retry a 400, so sending a sampling parameter to one of
+    these models fails the request outright.
+
+``max_output_tokens``
+    The per-response generation cap, sent as Bedrock Converse
+    ``inferenceConfig.maxTokens``. Requesting more is a 400. On models where
+    reasoning is always on, thinking tokens are drawn from this same budget, so
+    a cap sized only for the visible response truncates mid-tool-call and
+    raises ``MaxTokensReachedException``, which Strands treats as unrecoverable.
+
+Values are verified against Bedrock Converse rather than copied from
+documentation, because the documentation is inaccurate at the boundary. Both
+Anthropic and AWS describe Claude Sonnet 4.5 as having a "64K" output limit, but
+Bedrock rejects ``maxTokens=64000`` with::
+
+    The maximum tokens you requested exceeds the model limit of 64000.
+    Try again with a maximum tokens value that is lower than 64000.
+
+The limit is exclusive, so the largest usable value is 63999. Entries below
+store the largest *usable* value for that reason.
+
+Adding a new model family is one row in :data:`_MODEL_CAPABILITIES`. An
+unlisted family resolves to :data:`_DEFAULT_CAPABILITIES` and logs a warning
+once; see that constant for what the degraded behaviour is.
+"""
+
+from dataclasses import dataclass
+
+from ..logging import log_debug, log_warning
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """Capabilities of a Bedrock model family that affect how agents call it."""
+
+    # False for models that 400 on a non-default temperature/top_p/top_k.
+    accepts_sampling_params: bool
+
+    # Largest usable inferenceConfig.maxTokens. This is the documented ceiling
+    # minus one where the boundary is exclusive (see module docstring). Not the
+    # context window, which is much larger and counts input as well.
+    max_output_tokens: int
+
+
+# Matched as a substring against the full model id, so a single row covers every
+# form of an id: bare (``anthropic.claude-sonnet-5``), geo- or global-prefixed
+# (``global.``/``us.``/``eu.``/``au.``) and date-and-version suffixed
+# (``-20250929-v1:0``). No family substring is a prefix of another, so ordering
+# is not load-bearing; kept newest-first for readability.
+#
+# max_output_tokens provenance:
+#   claude-sonnet-4-5  63_999 - verified: Bedrock rejects 64000 as shown above.
+#   everything else    documented ceiling minus one. The exclusive boundary is
+#                      confirmed only for Sonnet 4.5, so the same margin is
+#                      applied conservatively rather than assuming an inclusive
+#                      limit elsewhere. Costs one token of headroom.
+_MODEL_CAPABILITIES: tuple[tuple[str, ModelCapabilities], ...] = (
+    (
+        "claude-sonnet-5",
+        ModelCapabilities(accepts_sampling_params=False, max_output_tokens=127_999),
+    ),
+    (
+        "claude-opus-4-8",
+        ModelCapabilities(accepts_sampling_params=False, max_output_tokens=127_999),
+    ),
+    (
+        "claude-opus-4-7",
+        ModelCapabilities(accepts_sampling_params=False, max_output_tokens=127_999),
+    ),
+    (
+        "claude-sonnet-4-6",
+        ModelCapabilities(accepts_sampling_params=True, max_output_tokens=127_999),
+    ),
+    (
+        "claude-sonnet-4-5",
+        ModelCapabilities(accepts_sampling_params=True, max_output_tokens=63_999),
+    ),
+    (
+        "claude-haiku-4-5",
+        ModelCapabilities(accepts_sampling_params=True, max_output_tokens=63_999),
+    ),
+)
+
+# Applied to any model family not listed above.
+#
+# accepts_sampling_params is permissive because that matches the behaviour older
+# models have always had. A future sampling-rejecting family that is not added
+# above will therefore be sent a temperature and 400. That is recoverable but
+# only reactively: the pre-flight probe in validation.aws_validator detects the
+# error and calls mark_model_no_sampling_support(), after which every model built
+# in this process omits sampling params. That recovery does not run under
+# --skip-validation, so a new rejecting family must still be added here.
+#
+# max_output_tokens is conservative rather than optimistic: it sits below the cap
+# of every model currently published, so an unlisted model is never sent a
+# maxTokens it will reject. The cost is that a large unlisted model is
+# under-used, which can surface as truncation on the heaviest agents until a row
+# is added.
+_DEFAULT_CAPABILITIES = ModelCapabilities(
+    accepts_sampling_params=True,
+    max_output_tokens=32_768,
+)
+
+
+# Model ids already warned about, so the warning is emitted once per id rather
+# than on every agent construction.
+_warned_unknown_models: set[str] = set()
+
+# Model ids observed at runtime to reject sampling parameters. Populated by
+# mark_model_no_sampling_support() and consulted by accepts_sampling_params(),
+# so a model the table does not know about can still be handled once Bedrock has
+# told us about it. Process-local: a long-lived MCP server learns once, whereas
+# each CLI invocation starts empty.
+_models_without_sampling_support: set[str] = set()
+
+
+def model_capabilities(model_id: str) -> ModelCapabilities:
+    """Resolve capabilities for a Bedrock model id by family substring match."""
+    for family, capabilities in _MODEL_CAPABILITIES:
+        if family in model_id:
+            return capabilities
+
+    if model_id not in _warned_unknown_models:
+        _warned_unknown_models.add(model_id)
+        log_warning(
+            f"Unknown model family '{model_id}' - using conservative defaults "
+            f"(sampling params allowed, max output {_DEFAULT_CAPABILITIES.max_output_tokens}). "
+            f"Add the family to _MODEL_CAPABILITIES in config/model_capabilities.py "
+            f"to use the model's real limits."
+        )
+    return _DEFAULT_CAPABILITIES
+
+
+def is_known_model(model_id: str) -> bool:
+    """True when the model id matches a registered family."""
+    return any(family in model_id for family, _ in _MODEL_CAPABILITIES)
+
+
+def accepts_sampling_params(model_id: str) -> bool:
+    """True when a non-default temperature/top_p/top_k may be sent.
+
+    Consults both the declared capability and anything learned at runtime, so a
+    model marked by :func:`mark_model_no_sampling_support` is honoured even when
+    the table claims otherwise.
+    """
+    if model_id in _models_without_sampling_support:
+        return False
+    return model_capabilities(model_id).accepts_sampling_params
+
+
+def mark_model_no_sampling_support(model_id: str) -> None:
+    """Record that a model rejected sampling parameters.
+
+    Called when Bedrock returns a ValidationException indicating temperature,
+    top_p or top_k is not accepted. Every model built afterwards in this process
+    omits sampling parameters for this id.
+    """
+    _models_without_sampling_support.add(model_id)
+
+
+def resolve_max_output_tokens(model_id: str, requested: int) -> int:
+    """Clamp a requested output budget to what the model will accept.
+
+    Agents declare the budget they want and this narrows it to the model's
+    ceiling, so pointing an agent at a smaller model can never produce a
+    maxTokens the model rejects. Requesting the full ceiling costs nothing:
+    Bedrock bills actual output, not the requested cap, and under-requesting
+    risks truncation.
+    """
+    ceiling = model_capabilities(model_id).max_output_tokens
+    if requested > ceiling:
+        log_debug(
+            f"Clamping max_tokens {requested} to {ceiling} for model '{model_id}'"
+        )
+        return ceiling
+    return requested
+
+
+# Sampling parameter names Bedrock may name in a rejection.
+_SAMPLING_PARAM_NAMES = ("temperature", "top_p", "top_k")
+
+# Phrasings seen or plausible in a sampling-parameter rejection. Matching a set
+# of markers rather than one exact string keeps detection working if the wording
+# changes; the observed message is "`temperature` is deprecated for this model".
+_REJECTION_MARKERS = (
+    "deprecated",
+    "not supported",
+    "unsupported",
+    "not accepted",
+    "cannot be used",
+    "may not be specified",
+)
+
+
+def is_sampling_param_error(error: Exception) -> bool:
+    """True when an exception looks like a sampling-parameter rejection."""
+    message = str(error).lower()
+    return any(name in message for name in _SAMPLING_PARAM_NAMES) and any(
+        marker in message for marker in _REJECTION_MARKERS
+    )
+
+
+def reset_runtime_state() -> None:
+    """Clear state learned at runtime. Intended for tests."""
+    _models_without_sampling_support.clear()
+    _warned_unknown_models.clear()

--- a/packages/threat-composer-ai/src/threat_composer_ai/validation/aws_validator.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/validation/aws_validator.py
@@ -10,8 +10,12 @@ from botocore.exceptions import (
 )
 from strands import Agent
 
-from ..agents.common import create_agent_model, mark_model_no_sampling_support
+from ..agents.common import create_agent_model
 from ..config import AppConfig
+from ..config.model_capabilities import (
+    is_sampling_param_error,
+    mark_model_no_sampling_support,
+)
 from ..logging import log_debug, log_error, log_success, log_warning
 
 
@@ -67,12 +71,6 @@ def get_aws_credential_info(config: AppConfig) -> dict[str, str]:
         }
 
 
-def _is_sampling_param_error(error: Exception) -> bool:
-    """Check if an exception is caused by unsupported sampling parameters."""
-    msg = str(error).lower()
-    return "temperature" in msg and "deprecated" in msg
-
-
 def validate_aws_bedrock_inference(config: AppConfig) -> bool:
     """ """
     try:
@@ -86,7 +84,7 @@ def validate_aws_bedrock_inference(config: AppConfig) -> bool:
         return True
 
     except Exception as e:
-        if _is_sampling_param_error(e):
+        if is_sampling_param_error(e):
             # Model doesn't support sampling params — cache this and retry without them
             log_warning(
                 f"Model {config.aws_model_id} does not support sampling parameters, retrying without temperature"
@@ -99,7 +97,9 @@ def validate_aws_bedrock_inference(config: AppConfig) -> bool:
                     callback_handler=None,
                 )
                 agent("Testing...")
-                log_success("Inference validated successfully (without sampling params)")
+                log_success(
+                    "Inference validated successfully (without sampling params)"
+                )
                 return True
             except Exception as retry_err:
                 log_error(f"Inference validation failed on retry: {str(retry_err)}")

--- a/packages/threat-composer-ai/tests/config/__init__.py
+++ b/packages/threat-composer-ai/tests/config/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the configuration package."""

--- a/packages/threat-composer-ai/tests/config/test_model_capabilities.py
+++ b/packages/threat-composer-ai/tests/config/test_model_capabilities.py
@@ -1,0 +1,265 @@
+"""
+Tests for the per-model Bedrock capability registry.
+
+These cover the two failure modes the registry exists to prevent:
+
+1. Sending a sampling parameter to a model that rejects it with a 400.
+2. Requesting an output budget above a model's ceiling, which is also a 400.
+
+The second one has bitten this package twice, both times because the documented
+"64K" limit for Sonnet 4.5 is exclusive - Bedrock rejects maxTokens=64000 with
+"Try again with a maximum tokens value that is lower than 64000". The
+resolved-budget test below is the regression guard for that.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from threat_composer_ai.agents.common import get_agent_model_config
+from threat_composer_ai.config.model_capabilities import (
+    _DEFAULT_CAPABILITIES,
+    _MODEL_CAPABILITIES,
+    accepts_sampling_params,
+    is_known_model,
+    is_sampling_param_error,
+    mark_model_no_sampling_support,
+    model_capabilities,
+    reset_runtime_state,
+    resolve_max_output_tokens,
+)
+
+# Hard per-response output limits enforced by Bedrock, as observed in its
+# rejection messages. The registry must always resolve to something STRICTLY
+# below these, because the limits are exclusive.
+HARD_OUTPUT_LIMITS = {
+    "global.anthropic.claude-sonnet-4-5-20250929-v1:0": 64_000,
+    "global.anthropic.claude-sonnet-5": 128_000,
+    "us.anthropic.claude-opus-4-7": 128_000,
+    "us.anthropic.claude-opus-4-8": 128_000,
+    "global.anthropic.claude-sonnet-4-6": 128_000,
+    "global.anthropic.claude-haiku-4-5-20251001-v1:0": 64_000,
+}
+
+# Every agent type the pipeline builds, plus the "test" type the pre-flight
+# inference probe uses.
+ALL_AGENT_TYPES = [
+    "application_info",
+    "architecture",
+    "architecture_diagram",
+    "dataflow",
+    "dataflow_diagram",
+    "threats",
+    "mitigations",
+    "threat_model",
+    "test",
+]
+
+MODELS_REJECTING_SAMPLING = [
+    "global.anthropic.claude-sonnet-5",
+    "us.anthropic.claude-sonnet-5",
+    "anthropic.claude-sonnet-5",
+    "us.anthropic.claude-opus-4-7",
+    "us.anthropic.claude-opus-4-8",
+]
+
+MODELS_ACCEPTING_SAMPLING = [
+    "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "global.anthropic.claude-sonnet-4-6",
+    "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime_state():
+    """Registry runtime caches are module level; isolate every test."""
+    reset_runtime_state()
+    yield
+    reset_runtime_state()
+
+
+class TestFamilyMatching:
+    """Ids are matched by family substring so one row covers every id form."""
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "anthropic.claude-sonnet-5",  # bare
+            "global.anthropic.claude-sonnet-5",  # global inference profile
+            "us.anthropic.claude-sonnet-5",  # geo profile
+            "eu.anthropic.claude-sonnet-5",
+            "au.anthropic.claude-sonnet-5",
+        ],
+    )
+    def test_prefixes_resolve_to_same_family(self, model_id):
+        assert is_known_model(model_id)
+        assert model_capabilities(model_id).max_output_tokens == 127_999
+        assert accepts_sampling_params(model_id) is False
+
+    def test_dated_and_versioned_suffix_resolves(self):
+        model_id = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        assert is_known_model(model_id)
+        assert model_capabilities(model_id).max_output_tokens == 63_999
+
+    def test_no_family_is_a_prefix_of_another(self):
+        """Guards the claim that row order is not load-bearing."""
+        families = [family for family, _ in _MODEL_CAPABILITIES]
+        for family in families:
+            others = [f for f in families if f != family]
+            assert not any(family in other for other in others), (
+                f"family {family!r} is a substring of another entry, "
+                f"which makes registry order significant"
+            )
+
+
+class TestUnknownModels:
+    def test_unknown_model_gets_conservative_defaults(self):
+        caps = model_capabilities("global.anthropic.claude-sonnet-6")
+        assert caps == _DEFAULT_CAPABILITIES
+        assert caps.max_output_tokens == 32_768
+
+    def test_unknown_model_is_not_known(self):
+        assert is_known_model("global.anthropic.claude-sonnet-6") is False
+
+    def test_default_budget_is_below_every_known_ceiling(self):
+        """An unlisted model must never be sent a budget a real model rejects."""
+        smallest = min(limit for limit in HARD_OUTPUT_LIMITS.values())
+        assert _DEFAULT_CAPABILITIES.max_output_tokens < smallest
+
+    def test_unknown_model_warns_once_per_id(self):
+        with patch(
+            "threat_composer_ai.config.model_capabilities.log_warning"
+        ) as mock_warn:
+            model_capabilities("anthropic.made-up-model")
+            model_capabilities("anthropic.made-up-model")
+            model_capabilities("anthropic.made-up-model")
+            assert mock_warn.call_count == 1
+
+    def test_known_model_does_not_warn(self):
+        with patch(
+            "threat_composer_ai.config.model_capabilities.log_warning"
+        ) as mock_warn:
+            model_capabilities("global.anthropic.claude-sonnet-5")
+            mock_warn.assert_not_called()
+
+
+class TestSamplingParams:
+    @pytest.mark.parametrize("model_id", MODELS_REJECTING_SAMPLING)
+    def test_rejecting_families(self, model_id):
+        assert accepts_sampling_params(model_id) is False
+
+    @pytest.mark.parametrize("model_id", MODELS_ACCEPTING_SAMPLING)
+    def test_accepting_families(self, model_id):
+        assert accepts_sampling_params(model_id) is True
+
+    def test_unknown_model_is_permissive(self):
+        """Matches historical behaviour for genuinely old models."""
+        assert accepts_sampling_params("anthropic.some-old-model") is True
+
+    def test_runtime_mark_overrides_the_table(self):
+        """The pre-flight probe must be able to correct an unlisted model."""
+        model_id = "anthropic.brand-new-rejecting-model"
+        assert accepts_sampling_params(model_id) is True
+
+        mark_model_no_sampling_support(model_id)
+        assert accepts_sampling_params(model_id) is False
+
+    def test_runtime_mark_is_per_model(self):
+        mark_model_no_sampling_support("anthropic.model-a")
+        assert accepts_sampling_params("anthropic.model-a") is False
+        assert accepts_sampling_params("anthropic.model-b") is True
+
+
+class TestSamplingParamErrorDetection:
+    def test_matches_observed_bedrock_message(self):
+        error = Exception(
+            "An error occurred (ValidationException) when calling the "
+            "ConverseStream operation: `temperature` is deprecated for this model"
+        )
+        assert is_sampling_param_error(error) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "top_p is deprecated for this model",
+            "top_k is not supported for this model",
+            "temperature is not accepted by this model",
+            "temperature may not be specified for this model",
+        ],
+    )
+    def test_matches_wording_variants(self, message):
+        """Detection should survive Bedrock rewording the rejection."""
+        assert is_sampling_param_error(Exception(message)) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "The maximum tokens you requested exceeds the model limit of 64000",
+            "An error occurred (AccessDeniedException)",
+            "An error occurred (ThrottlingException): Too many requests",
+            "Model not found",
+            "temperature is 0.3",  # names a param but is not a rejection
+        ],
+    )
+    def test_ignores_unrelated_errors(self, message):
+        assert is_sampling_param_error(Exception(message)) is False
+
+
+class TestBudgetClamping:
+    def test_request_below_ceiling_passes_through(self):
+        assert (
+            resolve_max_output_tokens("global.anthropic.claude-sonnet-5", 32_768)
+            == 32_768
+        )
+
+    def test_request_above_ceiling_is_clamped(self):
+        model_id = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        assert resolve_max_output_tokens(model_id, 100_000) == 63_999
+
+    def test_clamped_to_conservative_default_for_unknown_model(self):
+        assert resolve_max_output_tokens("anthropic.unlisted-model", 100_000) == 32_768
+
+    def test_larger_model_is_not_clamped_down_unnecessarily(self):
+        """Sonnet 5 must get the full budget Sonnet 4.5 cannot have."""
+        want = 100_000
+        assert (
+            resolve_max_output_tokens("global.anthropic.claude-sonnet-5", want) == want
+        )
+        assert (
+            resolve_max_output_tokens(
+                "global.anthropic.claude-sonnet-4-5-20250929-v1:0", want
+            )
+            < want
+        )
+
+
+class TestRegistryValuesAreUsable:
+    """Regression guards for the exclusive-limit bug."""
+
+    @pytest.mark.parametrize("model_id,hard_limit", HARD_OUTPUT_LIMITS.items())
+    def test_declared_ceiling_is_strictly_below_hard_limit(self, model_id, hard_limit):
+        declared = model_capabilities(model_id).max_output_tokens
+        assert declared < hard_limit, (
+            f"{model_id} declares {declared}, but Bedrock rejects anything "
+            f">= {hard_limit}. The documented limit is exclusive."
+        )
+
+    @pytest.mark.parametrize("model_id,hard_limit", HARD_OUTPUT_LIMITS.items())
+    @pytest.mark.parametrize("agent_type", ALL_AGENT_TYPES)
+    def test_every_agent_budget_is_accepted_by_every_known_model(
+        self, agent_type, model_id, hard_limit
+    ):
+        """No agent, on any known model, may resolve to a rejected budget.
+
+        This is the test that would have caught shipping 65536 and then 64000.
+        """
+        want = get_agent_model_config(agent_type)["max_tokens"]
+        resolved = resolve_max_output_tokens(model_id, want)
+        assert resolved < hard_limit
+
+    def test_unknown_model_budgets_are_accepted_by_the_smallest_known_model(self):
+        smallest = min(HARD_OUTPUT_LIMITS.values())
+        for agent_type in ALL_AGENT_TYPES:
+            want = get_agent_model_config(agent_type)["max_tokens"]
+            resolved = resolve_max_output_tokens("anthropic.unlisted", want)
+            assert resolved < smallest


### PR DESCRIPTION
## Problem

Per-agent `max_tokens` and `temperature` were sent to Bedrock as fixed values, independent of which model was actually in use. Both are model-dependent, and getting either wrong is a hard failure rather than a degradation:

- **Sampling parameters.** Newer Anthropic models reject a non-default `temperature` / `top_p` / `top_k` with a 400 `ValidationException` instead of ignoring it. botocore does not retry a 400, so the request simply fails. Previously this was only recovered reactively: a pre-flight probe caught the error and cached the model id. That works, but it costs a failed request on every CLI run, depends on matching the wording of a Bedrock error string, and does not run at all under `--skip-validation`.

- **Output budget.** Requesting a `maxTokens` above the model's cap is also a 400. Requesting too little is worse on a tool-calling agent: the response truncates mid-tool-call and Strands raises `MaxTokensReachedException`, which is unrecoverable and fails the whole run.

There is no way to look these up at runtime. `GetFoundationModel` returns modalities, streaming support and lifecycle only — no token limits, no capability flags — and the [inference configuration reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_TextInferenceConfig.html) states that its documented ranges are arbitrary and the real limits must be taken from the specific model. So capabilities have to be declared.

## What changed

A capability registry in `config/model_capabilities.py`, keyed by **model family substring**. One entry covers every id form for a family — bare, geo- or global-prefixed (`us.` / `eu.` / `global.`), and date-and-version suffixed — so adding a model is a single row rather than one per id variant.

Two things now resolve per model when an agent's `BedrockModel` is built:

- `temperature` is omitted for models that reject it, decided up front rather than discovered by a failed request. This also closes the `--skip-validation` gap for known models.
- `max_tokens` is **clamped** to the model's ceiling. Agents declare the budget they want and it is narrowed to what the model accepts, so pointing an agent at a smaller model can no longer produce a request that model rejects.

Clamping is what removes the class of bug here. There is no single constant that is simultaneously safe for a 64K model and generous for a 128K one, and picking one either wastes half the capacity of the larger model or breaks the smaller one.

The reactive probe is deliberately **kept**. An unlisted model that rejects sampling parameters still gets marked at runtime and recovers, so a future model family that nobody has added yet degrades rather than breaking outright. The registry is the fast, deterministic path; the probe remains the safety net.

Unlisted models resolve to conservative defaults — sampling params permitted, 32768 output, below the cap of every currently published model — and log a warning once per model id so a missing row shows up as a config gap rather than a mystery 400.

## Registry values are verified, not documented

Both Anthropic and AWS describe Claude Sonnet 4.5 as having a 64K output limit. Bedrock rejects `maxTokens=64000`:

```
An error occurred (ValidationException) when calling the ConverseStream operation:
The maximum tokens you requested exceeds the model limit of 64000.
Try again with a maximum tokens value that is lower than 64000.
```

The limit is exclusive, so the largest usable value is 63999. Entries store the largest *usable* budget for this reason, and the same one-token margin is applied to families whose boundary has not been individually confirmed.

## Behaviour change for existing users

The default model is unchanged in this PR. On Claude Sonnet 4.5, the `threats` and `dataflow_diagram` agents now request 63999 instead of 32768. Requesting a higher cap costs nothing — Bedrock bills actual output, not the requested maximum — and it removes truncation risk on larger codebases. Other agents move from 16384 to 32768 for the same reason.

## Testing

`98` new tests, `190` total, lint clean.

Unit coverage includes family matching across every id form, warn-once behaviour for unlisted models, runtime marking overriding the table, clamping in both directions, and sampling-error detection against the observed Bedrock message plus wording variants.

Two guard tests exist specifically to prevent regressing the exclusive-limit bug: every registry entry must be strictly below its model's hard limit, and every agent budget must resolve to an accepted value on every known model. Reintroducing `64_000` fails 8 tests, naming `threats` and `dataflow_diagram` on Sonnet 4.5 — the exact live failure.

Verified against Bedrock end to end:

- **Claude Haiku 4.5**, full pipeline, ~6 min. All eight agents completed; 20 threats, 20 mitigations, valid `threatmodel.tc.json`. Exercises the accepts-sampling and clamp-to-63999 path that the current default uses.
- **Claude Sonnet 5** via `--aws-model-id`, startup only. Probe reports `Inference validated successfully` on the first attempt with no sampling-parameter warning, confirming `temperature` is never sent rather than being retried away.
- **Claude Sonnet 5**, full pipeline, ~12 min. All eight agents completed; 20 threats, 31 mitigations, valid output. No truncation.

Model construction was also inspected directly for Sonnet 4.5, Sonnet 5, Opus 4.7 and an unlisted id, confirming what reaches `inferenceConfig`: no rejecting model receives a `temperature`, and no budget lands at or above any model's limit.

## Follow-up

A separate PR changes the default model to Claude Sonnet 5 and depends on this one. Sonnet 5 has adaptive thinking permanently enabled, and thinking tokens are drawn from the same output budget as the response, so the previous per-agent budgets truncate the `threats` agent and fail the run. That PR should not merge ahead of this change.
