### PR TITLE
feat(ai): Default to Claude Sonnet 5

### DIFF
--- a/docs/AI-CLI-MCP.md
+++ b/docs/AI-CLI-MCP.md
@@ -62,6 +62,8 @@ Threat Composer AI uses **Amazon Bedrock** for AI inference, which incurs costs 
 - **Model**: Claude Sonnet 5 (`global.anthropic.claude-sonnet-5`)
 - **Service Tier**: Standard on-demand (default)
 
+Claude Sonnet 5 always applies adaptive reasoning. Reasoning tokens are billed as output tokens, so output usage is higher than for a model without reasoning.
+
 **Estimated costs** vary based on codebase size and complexity. A typical threat model generation may use 500,000-1,500,000+ tokens depending on the project.
 
 For current pricing information, see:

--- a/docs/AI-CLI-MCP.md
+++ b/docs/AI-CLI-MCP.md
@@ -59,7 +59,7 @@ Without the extension, you can still view and edit the generated JSON files as t
 
 Threat Composer AI uses **Amazon Bedrock** for AI inference, which incurs costs based on token usage. By default, the tool uses:
 
-- **Model**: Claude Sonnet 4.5 (`global.anthropic.claude-sonnet-4-5-20250929-v1:0`)
+- **Model**: Claude Sonnet 5 (`global.anthropic.claude-sonnet-5`)
 - **Service Tier**: Standard on-demand (default)
 
 **Estimated costs** vary based on codebase size and complexity. A typical threat model generation may use 500,000-1,500,000+ tokens depending on the project.
@@ -155,7 +155,7 @@ threat-composer-ai-cli /path/to/codebase \
   --output-dir ./analysis-results \
   --aws-profile pineapple
   --aws-region us-west-2 \
-  --aws-model-id global.anthropic.claude-sonnet-4-5-20250929-v1:0 \
+  --aws-model-id global.anthropic.claude-sonnet-5 \
 
 # Basic usage with uvx
 uvx --from "git+https://github.com/awslabs/threat-composer.git#subdirectory=packages/threat-composer-ai" threat-composer-ai-cli /path/to/codebase

--- a/packages/threat-composer-ai/src/threat_composer_ai/config/app_config.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/config/app_config.py
@@ -56,7 +56,7 @@ class AppConfig:
 
     # AWS configuration
     aws_region: str = "us-west-2"
-    aws_model_id: str = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    aws_model_id: str = "global.anthropic.claude-sonnet-5"
     aws_profile: str | None = None
 
     # Runtime configuration


### PR DESCRIPTION
## Summary

Changes the default Bedrock model from Claude Sonnet 4.5 to Claude Sonnet 5.

Callers who set `THREAT_COMPOSER_AWS_MODEL_ID` or pass `--aws-model-id` are unaffected — this only moves the default.

> **Stacked on #327.** Base is `feat/model-capability-registry`, and this must not merge ahead of it. 

## Why this depends on #327

Sonnet 5 has adaptive reasoning permanently enabled, and reasoning tokens are drawn from the same output budget as the visible response. The per-agent `max_tokens` values tuned for Sonnet 4.5 are therefore too small: the `threats` agent truncates mid-tool-call, which surfaces as `MaxTokensReachedException` and fails the entire run.

Observed on this change before #327 existed:

```
handling max_tokens stop reason - replacing all tool uses with error messages
tool_name=<threat_composer_workdir_file_write> | replacing with error message due to max_tokens truncation.
❌ Agent has reached an unrecoverable state due to max_tokens limit
```

Sonnet 5 also rejects a non-default `temperature` with a 400 `ValidationException`. Without #327 that is only recovered by the pre-flight probe failing a request and retrying, which costs a wasted call on every run and does not happen at all under `--skip-validation`.

#327 resolves both per model, so this PR is a two-line default change on top of it.

## Testing

Full pipeline against Bedrock on this branch, analysing this repository: all eight agents completed and produced a valid `threatmodel.tc.json` with 20 threats and 31 mitigations. Roughly 12 minutes, 1,042,670 input and 80,980 output tokens.

Startup behaviour confirms the sampling-parameter path:

```
✅ Inference validated successfully
```

with no sampling-parameter warning and no `(without sampling params)` suffix, meaning `temperature` is never sent rather than being retried away. Before #327 the same run emitted:

```
⚠️  Model global.anthropic.claude-sonnet-5 does not support sampling parameters, retrying without temperature
✅ Inference validated successfully (without sampling params)
```

Unit tests: 190 passed, lint clean. No test asserted the previous default model id, so nothing needed updating.

## Docs

The cost section is updated to name Sonnet 5, and gains a note that its reasoning is always on and that reasoning tokens bill as output — relevant when estimating cost from the token ranges quoted there. The CLI example is updated to the new model id.
