### PR TITLE
fix(ai): Declare botocore[crt] for the login credential provider

### DIFF
--- a/packages/threat-composer-ai/.projen/deps.json
+++ b/packages/threat-composer-ai/.projen/deps.json
@@ -29,7 +29,7 @@
       "type": "runtime"
     },
     {
-      "name": "botocore",
+      "name": "botocore[crt]",
       "type": "runtime"
     },
     {

--- a/packages/threat-composer-ai/pyproject.toml
+++ b/packages/threat-composer-ai/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10"
 dependencies = [
   "bandit",
   "boto3",
-  "botocore",
+  "botocore[crt]",
   "click",
   "diagrams",
   "fastmcp",

--- a/packages/threat-composer-ai/src/threat_composer_ai/logging/rich_logger.py
+++ b/packages/threat-composer-ai/src/threat_composer_ai/logging/rich_logger.py
@@ -17,6 +17,7 @@ def rich_escape(value) -> str:
         value = str(value)
     return _rich_escape(value)
 
+
 # Custom theme for threat-composer-ai
 THREAT_COMPOSER_THEME = Theme(
     {
@@ -76,9 +77,7 @@ class AgentAwareFormatter(logging.Formatter):
         if record.agent == "system":
             formatted = f"[workflow]🔧 SYSTEM[/workflow] | {raw_message}"
         else:
-            formatted = (
-                f"[agent]🤖 {record.agent.upper()}[/agent] | {raw_message}"
-            )
+            formatted = f"[agent]🤖 {record.agent.upper()}[/agent] | {raw_message}"
 
         return formatted
 
@@ -225,9 +224,7 @@ def _log_markup(logger, level, message):
     """Log a message that contains pre-escaped Rich markup tags."""
     if not logger.isEnabledFor(level):
         return
-    record = logger.makeRecord(
-        logger.name, level, "(unknown)", 0, message, (), None
-    )
+    record = logger.makeRecord(logger.name, level, "(unknown)", 0, message, (), None)
     record._rich_markup_safe = True
     logger.handle(record)
 
@@ -236,21 +233,33 @@ def log_workflow_step(step_name: str, description: str = "") -> None:
     """Log a workflow step with special formatting."""
     logger = get_logger(__name__)
     if description:
-        _log_markup(logger, logging.INFO, f"[progress]📋 STEP: {rich_escape(step_name)}[/progress] - {rich_escape(description)}")
+        _log_markup(
+            logger,
+            logging.INFO,
+            f"[progress]📋 STEP: {rich_escape(step_name)}[/progress] - {rich_escape(description)}",
+        )
     else:
-        _log_markup(logger, logging.INFO, f"[progress]📋 STEP: {rich_escape(step_name)}[/progress]")
+        _log_markup(
+            logger,
+            logging.INFO,
+            f"[progress]📋 STEP: {rich_escape(step_name)}[/progress]",
+        )
 
 
 def log_agent_message(agent_name: str, action: str, details: str = "") -> None:
     """Log an agent action with special formatting."""
     logger = get_logger(__name__)
     if details:
-        _log_markup(logger, logging.INFO,
-            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [success]⚡ {rich_escape(action)}[/success] - {rich_escape(details)}"
+        _log_markup(
+            logger,
+            logging.INFO,
+            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [success]⚡ {rich_escape(action)}[/success] - {rich_escape(details)}",
         )
     else:
-        _log_markup(logger, logging.INFO,
-            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [success]⚡ {rich_escape(action)}[/success]"
+        _log_markup(
+            logger,
+            logging.INFO,
+            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [success]⚡ {rich_escape(action)}[/success]",
         )
 
 
@@ -258,12 +267,16 @@ def log_agent_tool_use(agent_name: str, action: str, details: str = "") -> None:
     """Log an agent action with special formatting."""
     logger = get_logger(__name__)
     if details:
-        _log_markup(logger, logging.INFO,
-            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [progress]🔨 {rich_escape(action)}[/progress] - {rich_escape(details)}"
+        _log_markup(
+            logger,
+            logging.INFO,
+            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [progress]🔨 {rich_escape(action)}[/progress] - {rich_escape(details)}",
         )
     else:
-        _log_markup(logger, logging.INFO,
-            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [progress]🔨 {rich_escape(action)}[/progress]"
+        _log_markup(
+            logger,
+            logging.INFO,
+            f"[agent]🤖 {rich_escape(agent_name.upper())}[/agent] | [progress]🔨 {rich_escape(action)}[/progress]",
         )
 
 
@@ -282,7 +295,9 @@ def log_error(message: str) -> None:
 def log_warning(message: str) -> None:
     """Log a warning message with special formatting."""
     logger = get_logger(__name__)
-    _log_markup(logger, logging.WARNING, f"[warning]⚠️  {rich_escape(message)}[/warning]")
+    _log_markup(
+        logger, logging.WARNING, f"[warning]⚠️  {rich_escape(message)}[/warning]"
+    )
 
 
 def log_debug(message: str) -> None:
@@ -296,11 +311,15 @@ def log_model_config(
 ) -> None:
     """Log model configuration at startup with special formatting."""
     logger = get_logger(__name__)
-    _log_markup(logger, logging.INFO,
-        f"[success]🤖 MODEL CONFIG | Model: {rich_escape(model_id)} | Source: {rich_escape(model_source)}[/success]"
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[success]🤖 MODEL CONFIG | Model: {rich_escape(model_id)} | Source: {rich_escape(model_source)}[/success]",
     )
-    _log_markup(logger, logging.INFO,
-        f"[success]🤖 MODEL CONFIG | Region: {rich_escape(region)} | Source: {rich_escape(region_source)}[/success]"
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[success]🤖 MODEL CONFIG | Region: {rich_escape(region)} | Source: {rich_escape(region_source)}[/success]",
     )
 
 
@@ -312,37 +331,77 @@ def log_startup_banner(config, sources: dict[str, str]) -> None:
 
     # Banner header
     _log_markup(logger, logging.INFO, "[workflow]" + "=" * 80 + "[/workflow]")
-    _log_markup(logger, logging.INFO, "[workflow]🚀 THREAT COMPOSER AI - WORKFLOW STARTING[/workflow]")
+    _log_markup(
+        logger,
+        logging.INFO,
+        "[workflow]🚀 THREAT COMPOSER AI - WORKFLOW STARTING[/workflow]",
+    )
     _log_markup(logger, logging.INFO, "[workflow]" + "=" * 80 + "[/workflow]")
 
     # Invocation source
     invocation_emoji = "💻" if config.invocation_source == "CLI" else "🔌"
-    _log_markup(logger, logging.INFO, f"[success]{invocation_emoji} INVOCATION SOURCE: {rich_escape(config.invocation_source)}[/success]")
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[success]{invocation_emoji} INVOCATION SOURCE: {rich_escape(config.invocation_source)}[/success]",
+    )
 
     # Session info
     session_id = config.output_directory.name
-    _log_markup(logger, logging.INFO, f"[info]📋 SESSION ID: {rich_escape(session_id)}[/info]")
+    _log_markup(
+        logger, logging.INFO, f"[info]📋 SESSION ID: {rich_escape(session_id)}[/info]"
+    )
 
     # AWS Configuration
     _log_markup(logger, logging.INFO, "[workflow]" + "-" * 80 + "[/workflow]")
     _log_markup(logger, logging.INFO, "[workflow]☁️  AWS CONFIGURATION[/workflow]")
-    _log_markup(logger, logging.INFO, f"[success]  Profile: {rich_escape(config.aws_profile)} | Source: {rich_escape(sources.get('aws_profile', 'unknown'))}[/success]")
-    _log_markup(logger, logging.INFO, f"[success]  Region: {rich_escape(config.aws_region)} | Source: {rich_escape(sources.get('aws_region', 'unknown'))}[/success]")
-    _log_markup(logger, logging.INFO, f"[success]  Model ID: {rich_escape(config.aws_model_id)} | Source: {rich_escape(sources.get('aws_model_id', 'unknown'))}[/success]")
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[success]  Profile: {rich_escape(config.aws_profile)} | Source: {rich_escape(sources.get('aws_profile', 'unknown'))}[/success]",
+    )
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[success]  Region: {rich_escape(config.aws_region)} | Source: {rich_escape(sources.get('aws_region', 'unknown'))}[/success]",
+    )
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[success]  Model ID: {rich_escape(config.aws_model_id)} | Source: {rich_escape(sources.get('aws_model_id', 'unknown'))}[/success]",
+    )
 
     # Directories
     _log_markup(logger, logging.INFO, "[workflow]" + "-" * 80 + "[/workflow]")
     _log_markup(logger, logging.INFO, "[workflow]📁 DIRECTORIES[/workflow]")
-    _log_markup(logger, logging.INFO, f"[info]  Working: {rich_escape(str(config.working_directory))}[/info]")
-    _log_markup(logger, logging.INFO, f"[info]  Output: {rich_escape(str(config.output_directory))}[/info]")
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[info]  Working: {rich_escape(str(config.working_directory))}[/info]",
+    )
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[info]  Output: {rich_escape(str(config.output_directory))}[/info]",
+    )
 
     # Runtime Configuration
     _log_markup(logger, logging.INFO, "[workflow]" + "-" * 80 + "[/workflow]")
     _log_markup(logger, logging.INFO, "[workflow]⚙️  RUNTIME CONFIGURATION[/workflow]")
-    _log_markup(logger, logging.INFO, f"[info]  Execution Timeout: {config.execution_timeout}s[/info]")
-    _log_markup(logger, logging.INFO, f"[info]  Node Timeout: {config.node_timeout}s[/info]")
-    _log_markup(logger, logging.INFO, f"[info]  Verbose Logging: {config.verbose}[/info]")
-    _log_markup(logger, logging.INFO, f"[info]  Telemetry: {config.enable_telemetry}[/info]")
+    _log_markup(
+        logger,
+        logging.INFO,
+        f"[info]  Execution Timeout: {config.execution_timeout}s[/info]",
+    )
+    _log_markup(
+        logger, logging.INFO, f"[info]  Node Timeout: {config.node_timeout}s[/info]"
+    )
+    _log_markup(
+        logger, logging.INFO, f"[info]  Verbose Logging: {config.verbose}[/info]"
+    )
+    _log_markup(
+        logger, logging.INFO, f"[info]  Telemetry: {config.enable_telemetry}[/info]"
+    )
 
     # Banner footer
     _log_markup(logger, logging.INFO, "[workflow]" + "=" * 80 + "[/workflow]")

--- a/packages/threat-composer-ai/uv.lock
+++ b/packages/threat-composer-ai/uv.lock
@@ -236,6 +236,35 @@ wheels = [
 ]
 
 [[package]]
+name = "awscrt"
+version = "0.27.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/cf/fb5af0ffac5b3b43d12323ecf7be03da7fd32c5bcb6bb9749d4ff5802698/awscrt-0.27.6.tar.gz", hash = "sha256:45f3dd0b3fb13dfbea856dd96c9acfe77beba57b9b019444ee962ed2b76276dd", size = 37677550, upload-time = "2025-08-12T20:28:04.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/b7/f283003df7d6d4a7d43229643181eaa0bfcc013f49547a62993521c2eb63/awscrt-0.27.6-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:181f5bcb4703bc6f91ed528616f86a642c5342b1ed04543937dba3b13c868c88", size = 3327348, upload-time = "2025-08-12T20:27:04.799Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ab/2b06d4308d06e0272432f790c296cf01a955bf9e5e7095bb886b2e696aa7/awscrt-0.27.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:705f591eb5354e9295e01169a2077dfc6198f477bc730079610e55a2ebb46c26", size = 3766525, upload-time = "2025-08-12T20:27:08.287Z" },
+    { url = "https://files.pythonhosted.org/packages/45/75/48e56fb4c1b76066842d0070f1d2873e119d87df71e243c03390d93cf7df/awscrt-0.27.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32c9aa4b82a3dc07ebd6c549e6e8690995569e2f648a67729068f4313f12f8f4", size = 4028416, upload-time = "2025-08-12T20:27:09.78Z" },
+    { url = "https://files.pythonhosted.org/packages/66/23/d3235845ef9bb6f2b310b554e31c5de5fb104cc176f43d426e1d4c6eb3c5/awscrt-0.27.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c42ffcc8dc0ea06cab1f66506b5ed3861769785bebdadad1d70a911305b4ec44", size = 3691926, upload-time = "2025-08-12T20:27:11.323Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/98/5a9508edafe3c9c2e913d52a1e91a58a2c0dba6083144ce333aeebe1a479/awscrt-0.27.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:030eb7d70b7a6a40f503dde0df70cf5d9f1d55bd5e30c222f317ea9e2c9172c9", size = 3915325, upload-time = "2025-08-12T20:27:12.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d3/6a2a019d18226e2c225526b9e126dc31d78ec05453d23f300b0c03dcd223/awscrt-0.27.6-cp310-cp310-win32.whl", hash = "sha256:c3bddd393cec9e7470526785956fa01623fcbf38d043e4ea60c38d4b972c1f44", size = 3855894, upload-time = "2025-08-12T20:27:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/af/24/d1ce344a2754e4f8f44b8c46429b80327986293f3b445216443c1ccedcb1/awscrt-0.27.6-cp310-cp310-win_amd64.whl", hash = "sha256:87d085a626ac9e038cd90f01521acca5ade31eba044d9c109118502b06f23ad3", size = 3989764, upload-time = "2025-08-12T20:27:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/de/ee7c1ebb8d63336a2962c661baa20eef4862a69a87b08cef4491df7cfaec/awscrt-0.27.6-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:7796105413de8d3de8ce58ad3184710f7e533b62aac4662bea4e53bf63ab88ae", size = 3327369, upload-time = "2025-08-12T20:27:17.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8c/e4b2e27c3551ce7c0d86a333c41078274424ad8c3a14500244335eedc534/awscrt-0.27.6-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:66991c84992f18165e4e0d33730c447697f1696484d350d5b8f0e474ef70adda", size = 3728181, upload-time = "2025-08-12T20:27:18.992Z" },
+    { url = "https://files.pythonhosted.org/packages/de/65/a326d255595a6650f9af314e124de85d5b1dc03b1be8717db51483e95e10/awscrt-0.27.6-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:786476667b414476b152896d13f213a17e55d058bd3da414e43b020b5375e453", size = 3990158, upload-time = "2025-08-12T20:27:20.167Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6b/538828977cd4dcc4686ceba4d198df664570e805007fa801336a38789414/awscrt-0.27.6-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:8bda649a0f8ecf2b5b9e7610508e88c8040d51210eaa4339f08acec0ce2811f6", size = 3634922, upload-time = "2025-08-12T20:27:21.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9e/2739d3ca058744e49026619c73d66be23a3323d44c1ac0ff600bc84466ef/awscrt-0.27.6-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:795ccafe031198074a09b4ddd0e1ec08e021d205c443163c4060501a415677a9", size = 3857946, upload-time = "2025-08-12T20:27:23.192Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ea/e12de6343696fe31c56910ea08cfc4bf4cdd3aa65d8d1f7bb1537c7800a0/awscrt-0.27.6-cp311-abi3-win32.whl", hash = "sha256:7f3109f3cbdee9929d90d283547872ca742fc53990ca204527b60d9fba5d5f1d", size = 3853299, upload-time = "2025-08-12T20:27:24.413Z" },
+    { url = "https://files.pythonhosted.org/packages/22/10/9cfb2af6f805e8663df8f6787bed0174101f09cb56692fb0779b45511996/awscrt-0.27.6-cp311-abi3-win_amd64.whl", hash = "sha256:c249476f87fcd8efcfe25fd09785b6b0362e54241ba6a14fa66e4afe93d419bd", size = 3987659, upload-time = "2025-08-12T20:27:25.718Z" },
+    { url = "https://files.pythonhosted.org/packages/32/54/07fc7fa2e2ca6dabaa8f21276f5813452488e9811d9dd6f081af9b7db458/awscrt-0.27.6-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:12652f75c6f4a56d096405beac7c5c89bb7cf4d5eed7edf7d23a214e97379d2f", size = 3326418, upload-time = "2025-08-12T20:27:27.013Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5c/592b29b7ceeb39fa8595b5a6da9efc0cd139806af764b57b0492deda941c/awscrt-0.27.6-cp313-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d9a4a928f83618864fbe37901cb60df6bf456f10986be57d6bc36bf7ca2be07", size = 3718094, upload-time = "2025-08-12T20:27:28.233Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ee/06c64f3f5acec2a8680d0a3f1ef29847356ca38c899a1088efc22871993c/awscrt-0.27.6-cp313-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a36bab2b7994d7622bc5726bea5d6a651edb669083b9acbfe176ef05fd4e1c5", size = 3986230, upload-time = "2025-08-12T20:27:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/12/19/5ce0466c9cc127645af2c4b628a880ad0f1146b64586da7b56471c54c2fc/awscrt-0.27.6-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:2b79917a5a6a3f0229b3cbc2857d0b9254be5eb203f9b55fec086324372050f4", size = 3626033, upload-time = "2025-08-12T20:27:30.722Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/5f70578c75c4ca6b85f54bf67c0a348cc99d4867bed492ee46c00d1a8527/awscrt-0.27.6-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:fdf6406de9d6ff510cccba6ca020a248d2d673c9c5440c06f2c21a4ae7555672", size = 3852807, upload-time = "2025-08-12T20:27:32.36Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0d/3cc10aa112f451974351ce4c62c8fa3bbc00c9c1f570c7710abd6d8cd0c5/awscrt-0.27.6-cp313-abi3-win32.whl", hash = "sha256:50e300d6840d99bdbe57aec871d9958fae9dc54aa71430f1278470a79843b982", size = 3851030, upload-time = "2025-08-12T20:27:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6c/a546c9e4686434a095713325d231237c79aa6a23712b8920e4096afd75eb/awscrt-0.27.6-cp313-abi3-win_amd64.whl", hash = "sha256:718af70271b9e1d32372e7802ee98b5df6b0b7908f4fa9025fcc398091aaf373", size = 3983932, upload-time = "2025-08-12T20:27:35.318Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -316,6 +345,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/d6/dc11fecf450c60175fd568791e2324e059e81bc4adac85d83f272ab293f5/botocore-1.40.62.tar.gz", hash = "sha256:1e8e57c131597dc234d67428bda1323e8f0a687ea13ea570253159ab9256fa28", size = 14389174, upload-time = "2025-10-29T21:33:03.209Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/de/be9e3d25e6d114dfd0bb2dd42c9c3ae78b693b5e519a736b76f505fdb0d1/botocore-1.40.62-py3-none-any.whl", hash = "sha256:780f1d476d4b530ce3b12fd9f7112156d97d99ebdbbd9ef60635b0432af9d3a5", size = 14056496, upload-time = "2025-10-29T21:33:00.401Z" },
+]
+
+[package.optional-dependencies]
+crt = [
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -2921,7 +2955,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bandit" },
     { name = "boto3" },
-    { name = "botocore" },
+    { name = "botocore", extra = ["crt"] },
     { name = "click" },
     { name = "diagrams" },
     { name = "fastmcp" },
@@ -2954,7 +2988,7 @@ dev = [
 requires-dist = [
     { name = "bandit" },
     { name = "boto3" },
-    { name = "botocore" },
+    { name = "botocore", extras = ["crt"] },
     { name = "click" },
     { name = "diagrams" },
     { name = "fastmcp" },

--- a/projenrc/ai-cli-mcp.ts
+++ b/projenrc/ai-cli-mcp.ts
@@ -24,7 +24,19 @@ export default class ThreatComposerPythonAIProject extends UvPythonProject {
         "strands-agents-tools",
         "click",
         "boto3",
-        "botocore",
+        // [crt] pulls in awscrt, which the login credential provider requires.
+        // The AWS SDKs and Tools reference lists Boto3 support for the login
+        // provider as "Requires CRT"; without it, resolving credentials from a
+        // profile that uses login_session fails with MissingDependencyException
+        // before any AWS call is made.
+        //
+        // Declared on botocore rather than boto3 because that is the package
+        // botocore's own error message names, and the form the Strands docs
+        // recommend for `aws login`. boto3[crt] would be equivalent -- it
+        // resolves to botocore[crt] -- but matching the error text is easier to
+        // follow. Profiles using static credentials, environment variables or
+        // credential_process resolve earlier in the chain and are unaffected.
+        "botocore[crt]",
         "rich",
         "json-schema-to-pydantic",
         "pathspec",


### PR DESCRIPTION
## What this changes

Declares `botocore[crt]` instead of `botocore`, which installs `awscrt`.

## Scope

This affects users whose AWS profile uses `login_session` (set by `aws login`). For them, credential resolution raises `MissingDependencyException` and the CLI or MCP server cannot start:

```
MissingDependencyException: Missing Dependency: Using the login credential provider
requires an additional dependency. You will need to pip install "botocore[crt]"
before proceeding.
```

Everyone else is unaffected and sees no behavioural change. Static credentials, environment variables, SSO and `credential_process` all resolve earlier in botocore's chain, so the login provider is never reached. The tool works fine today for most people — this is not a broad breakage, and there's no urgency to it.

There is also an existing workaround that works, so nobody is blocked while this is discussed. Adding `--with "botocore[crt]"` to the uvx args:

```json
"threat-composer-ai": {
  "command": "uvx",
  "args": [
    "--from", "git+https://github.com/awslabs/threat-composer.git#subdirectory=packages/threat-composer-ai",
    "--with", "botocore[crt]",
    "threat-composer-ai-mcp"
  ]
}
```

## Context: this is a public AWS feature

`aws login` is documented in the [AWS SDKs and Tools reference](https://docs.aws.amazon.com/sdkref/latest/guide/feature-login-credentials.html) and the [AWS CLI user guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html), supported across CLI v2, C++, Go v1, Java 2.x, JavaScript 3.x, Kotlin, .NET, PHP, Ruby, Rust and PowerShell V5. Against Python that table reads:

> SDK for Python (Boto3) — Yes — Requires CRT

## Options, and why this one

Three reasonable ways to handle it:

1. **Declare it (this PR).** Works out of the box. Costs every user a compiled dependency they may not need.
2. **Optional extra**, e.g. `threat-composer-ai[crt]`. Nobody pays who doesn't need it, but the failure gives no hint that an extra exists, and the docs' `uvx` invocation would need two variants.
3. **Document the workaround only.** Zero cost to anyone, but the first experience for an affected user is a crash.

I went with 1 on the grounds that this package is an application — console scripts, documented for `uv tool install` and `uvx` — so it installs into its own isolated environment rather than being bundled into someone else's deployment, and the affected user's only alternative is hand-editing MCP JSON.

**Reviewers may reasonably prefer 2 or 3.** Notably, Strands hit this same issue upstream ([strands-agents/harness-sdk#1486](https://github.com/strands-agents/harness-sdk/issues/1486)) and chose to document it rather than add CRT as a required dependency, on the grounds of CRT's weight for all consumers including deployments. That reasoning applies less to a standalone application than to a library, but it's a fair counter-argument and I'd rather surface it than argue past it. Happy to switch to an extra if that's the preference.

## Costs, stated plainly

- `botocore` pins `awscrt` to an exact version (`awscrt==0.36.0` on current botocore), which can conflict in a shared resolver graph. Less of an issue for an app in an isolated environment than for a library.
- `awscrt` is compiled. It does publish 21 prebuilt wheels — macOS `universal2`, Linux `manylinux` and `musllinux` on `x86_64` and `aarch64`, Windows `win32` and `win_amd64`, with `abi3` for 3.11+ — so no mainstream platform builds from source, and the download is ~3 MB. But it is still native code in the tree.
- Users who don't use `aws login` get no benefit from any of it.

## Where the change was made

`projenrc/ai-cli-mcp.ts` is the source of truth. `pyproject.toml` and `.projen/deps.json` are projen-generated and were regenerated by running projen, not hand-edited. `uv.lock` adds `awscrt`.

Declared on `botocore` rather than `boto3` because that's the package botocore's own error message names, and the form the [Strands docs](https://github.com/strands-agents/docs/pull/437) recommend for `aws login`. `boto3[crt]` would be equivalent — it resolves to `botocore[crt]` — but matching the error text is easier for users to follow.

## Verification

Reproduced with a throwaway `AWS_CONFIG_FILE` containing only `login_session`, so the provider is actually reached rather than shadowed:

| Install | awscrt | Result |
| --- | --- | --- |
| `boto3` | absent | `MissingDependencyException` — the reported error |
| `botocore[crt]` | present | provider works, reaches `LoginTokenLoadError` for the deliberately fake session ARN |

The second row is the expected outcome for a session that was never authenticated, so the dependency error is gone and the provider is functioning.

A fresh install of the package from this branch, matching the `uvx --from git+...` invocation in the docs, resolves botocore 1.43.73 and pulls `awscrt`.

One note for anyone trying to reproduce: the botocore version pinned in `uv.lock` has no login provider at all, so this cannot be reproduced from the committed dev environment. `uvx` and `uv tool install` resolve fresh and get a botocore that has it, which is why end users hit this and local development doesn't.

Tests: 92 passed. Ruff check and format clean.

## Follow-up, not included

`MissingDependencyException` currently falls through to a generic "Unexpected error during AWS validation", which tells the user nothing useful. That's worth fixing regardless of which option above is chosen, and it helps anyone already running an older install. Small, separate change.

## Included formatting commit

`b0e4ee5` applies `ruff format` to `rich_logger.py` and `aws_validator.py`. Both were committed unformatted, so `ruff format --check .` fails — one of two reasons the husky pre-commit hook can't pass on a fresh checkout once dependencies are installed. Formatting only, no behaviour change, kept as its own commit so it's easy to drop.

The other reason is unrelated to Python: `yarn workspaces run eslint` reports 42 `import/no-unresolved` errors for `@aws/threat-composer` until that workspace is built, so a contributor who runs `yarn install` and commits without building first is blocked. Not addressed here.
