### PR TITLE
ci(python): Run ruff in CI and repair the pytest config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,9 @@ jobs:
       - run: pdk install --frozen-lockfile
       - run: PATH=/tmp/git-secrets/bin:$PATH pdk run build
       - run: pdk workspaces run eslint
+      # threat-composer-ai is an nx project, not a yarn workspace, so the line
+      # above does not reach it. Its pytest suite already runs as part of
+      # `pdk run build` (threat-composer-ai:build spawns test), but nothing
+      # invokes its ruff target, so lint has been enforced only by the
+      # pre-commit hook. This gives CI parity with the hook.
+      - run: yarn nx run threat-composer-ai:lint

--- a/packages/threat-composer-ai/pytest.ini
+++ b/packages/threat-composer-ai/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*


### PR DESCRIPTION
Two small gaps in how `packages/threat-composer-ai` is checked.

## Ruff never ran in CI

The package declares a `lint` nx target (`ruff check` plus `ruff format --check`), but nothing invoked it. Its `build` target spawns pre-compile, compile, post-compile, test and package, not lint, and `pdk workspaces run eslint` only covers yarn workspaces, which `threat-composer-ai` is not. Enforcement was therefore limited to the pre-commit hook, so anything pushed without the hook installed went unchecked. This adds the target to the workflow, giving CI parity with the hook.

The pytest suite is unaffected and already ran: `pdk run build` reaches `threat-composer-ai:build`, which spawns `test`. 190 tests, unchanged.

## pytest.ini was silently ignoring itself

It used a `[tool:pytest]` section header, which is the `setup.cfg` form. In a standalone `pytest.ini` pytest looks for `[pytest]`, so `testpaths`, `addopts` and `filterwarnings` were all discarded, while pytest still printed `configfile: pytest.ini`. That is what made it invisible.

Verified with a controlled A/B on pytest 9.0.3, two identical projects differing only in the header:

```
[pytest]        -> test_ok PASSED       (addopts = -v applied)
[tool:pytest]   -> 1 passed in 0.01s    (addopts silently dropped)
```

Corrected to `[pytest]`, which activates the intended `-v --tb=short` and the DeprecationWarning filters.

## Verification

Full CI sequence run locally in order on Node 20: `projen build` OK, `workspaces run eslint` OK, the new `threat-composer-ai:lint` step OK, 190 pytest passing, working tree clean afterwards.

## Notes

- Two files. No projen changes are needed, because `.github/workflows/build.yml` is not projen-managed.
- This has not yet run in GitHub Actions.
- First of a stack of three. The next two are the e2e suite and the pnpm/nx/Vite migration.

## Stack

Review in order. Each PR targets the one below it, so each diff shows only its own change.

1. #331 `ci/python-lint-and-pytest-config` (2 files)
2. #332 `test/e2e-web-app` (44 files)
3. #333 `build/pnpm-nx-vite-esm` (619 files)

